### PR TITLE
[feat#10] 팀 로비 페이지 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import type { CurrentUser, Note, Team } from "./types";
 export default function App() {
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
 
+  // --- 데이터 로직 (Custom Hook) ---
   const {
     teams,
     setTeams,
@@ -33,6 +34,7 @@ export default function App() {
     addLog,
   } = useTeams(currentUser);
 
+  // --- UI 상태 관리 ---
   const [view, setView] = useState<"dashboard" | "members" | "archive">(
     "dashboard"
   );
@@ -48,6 +50,9 @@ export default function App() {
   const selectedTicket =
     activeTeam?.tickets.find((t) => t.id === selectedTicketId) ?? null;
 
+  // --- 브릿지 핸들러 (UI + Data Logic) ---
+
+  // 새 팀 생성 (Lobby 전용)
   const handleCreateTeam = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!currentUser) return;
@@ -84,6 +89,7 @@ export default function App() {
     addLog(0, currentUser.name, "새 프로젝트 개설", "info");
   };
 
+  // 팀 인증 (Lobby 전용)
   const handleTeamAuth = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -129,17 +135,26 @@ export default function App() {
   const createTicket = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    // 1. FormData 객체 생성
     const formData = new FormData(e.currentTarget);
+
+    // 2. input 태그의 name 속성으로 값을 가져옴
     const title = formData.get("title") as string;
     const content = formData.get("content") as string;
     const worker = formData.get("worker") as string;
 
+    console.log(title, content, worker);
+
+    // 3. 값이 비어있는지 검증 (하나라도 없으면 생성 안 됨)
     if (!title.trim() || !content.trim() || !worker) {
       alert("모든 항목을 입력해주세요.");
       return;
     }
 
+    // 4. 훅에서 가져온 함수 호출 (인자 순서 확인!)
     handleCreateTicket(title, content, worker);
+
+    // 5. 모달 닫기
     setActiveModal(null);
   };
 
@@ -182,6 +197,7 @@ export default function App() {
     setActiveModal(null);
   };
 
+  // --- 조건부 렌더링 (Auth & Lobby) --
   if (!currentUser) {
     return authPage === "login" ? (
       <Login
@@ -206,6 +222,7 @@ export default function App() {
           setIsTeamAuthModalOpen={() => setActiveModal("auth")}
         />
 
+        {/* 로비 전용 모달 시스템 */}
         <Modal
           isOpen={activeModal === "createTeam"}
           onClose={() => setActiveModal(null)}
@@ -268,6 +285,7 @@ export default function App() {
     );
   }
 
+  // --- 메인 레이아웃 (인증 완료 후) ---
   return (
     <div className="flex h-screen bg-slate-50 overflow-hidden">
       <Sidebar
@@ -318,18 +336,21 @@ export default function App() {
         </div>
       </main>
 
+      {/* --- 메인 앱 모달 시스템 --- */}    
       <Modal
         isOpen={activeModal === "create"}
         onClose={() => setActiveModal(null)}
         title="새로운 업무 요청"
       >
         <form onSubmit={createTicket} className="space-y-6">
+          {/* name="title" 확인 */}
           <input
             name="title"
             required
             className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none font-bold"
             placeholder="제목"
           />
+          {/* name="worker" 확인 */}
           <select
             name="worker"
             className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none font-bold"
@@ -341,6 +362,7 @@ export default function App() {
               </option>
             ))}
           </select>
+          {/* name="content" 확인 */}
           <textarea
             name="content"
             required
@@ -439,7 +461,8 @@ export default function App() {
           </button>
         </form>
       </Modal>
-
+      
+      {/* 상세 페이지/모달 */}
       {selectedTicket && currentUser && (
         <TicketDetail
           ticket={selectedTicket}

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -1,0 +1,85 @@
+import type { Team, CurrentUser } from "../types";
+import { INITIAL_TEAM } from "../utils/constants";
+
+// 임시 팀 데이터 저장소
+let mockTeams: Team[] = [INITIAL_TEAM];
+
+// 팀 목록 조회용 임시 API
+export const getTeamsApi = async (): Promise<Team[]> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(mockTeams);
+    }, 300);
+  });
+};
+
+// 팀 생성용 임시 API
+export const createTeamApi = async (newTeam: Team): Promise<Team> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      mockTeams = [...mockTeams, newTeam];
+      resolve(newTeam);
+    }, 300);
+  });
+};
+
+// 팀 가입용 임시 API
+export const joinTeamApi = async (
+  teamId: string,
+  user: CurrentUser
+): Promise<Team | null> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      let updatedTeam: Team | null = null;
+
+      mockTeams = mockTeams.map((team) => {
+        if (team.id !== teamId) return team;
+
+        const alreadyJoined = team.members.some(
+          (member) => member.name === user.name
+        );
+
+        if (alreadyJoined) {
+          updatedTeam = team;
+          return team;
+        }
+
+        const nextTeam = {
+          ...team,
+          members: [...team.members, user],
+        };
+
+        updatedTeam = nextTeam;
+        return nextTeam;
+      });
+
+      resolve(updatedTeam);
+    }, 300);
+  });
+};
+
+// 팀 탈퇴용 임시 API
+export const leaveTeamApi = async (
+  teamId: string,
+  userName: string
+): Promise<Team | null> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      let updatedTeam: Team | null = null;
+
+      mockTeams = mockTeams.map((team) => {
+        if (team.id !== teamId) return team;
+
+        const nextTeam = {
+          ...team,
+          members: team.members.filter((member) => member.name !== userName),
+        };
+
+        updatedTeam = nextTeam;
+        return nextTeam;
+      });
+
+      resolve(updatedTeam);
+    }, 300);
+  });
+};

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -3,20 +3,36 @@
  * @description 팀 데이터(Team), 티켓(Ticket), 활동 로그(Log)의 상태 관리 및 비즈니스 로직을 총괄합니다.
  * @param currentUser 현재 접속한 유저 정보 (로그 기록 및 권한 확인용)
  */
-import { useState, useMemo } from 'react';
-import type { Team, Ticket, CurrentUser } from '../types';
-import { INITIAL_TEAM } from '../utils/constants';
-import { formatLogTime } from '../utils/format';
+import { useState, useMemo } from 'react'
+import type { Team, Ticket, CurrentUser } from '../types'
+import { INITIAL_TEAM } from '../utils/constants'
+import { formatLogTime } from '../utils/format'
 
-  // 상태 관리 - 팀 리스트 및 참여중인 팀 ID
+// 상태 관리 - 팀 리스트 및 참여중인 팀 ID
 export const useTeams = (currentUser: CurrentUser | null) => {
-  const [teams, setTeams] = useState<Team[]>([INITIAL_TEAM]);
-  const [activeTeamId, setActiveTeamId] = useState<string | null>(null);
+  const [teams, setTeams] = useState<Team[]>([INITIAL_TEAM])
+  const [activeTeamId, setActiveTeamId] = useState<string | null>(null)
 
   // 현재 활성화된 팀 객체를 실시간으로 찾아 유지
   const activeTeam = useMemo(() => {
-    return teams.find((t) => t.id === activeTeamId) ?? null;
-  }, [teams, activeTeamId]);
+    return teams.find((t) => t.id === activeTeamId) ?? null
+  }, [teams, activeTeamId])
+
+  // 현재 유저가 참여 중인 팀 목록
+  const joinedTeams = useMemo(() => {
+    if (!currentUser) return []
+    return teams.filter((team) =>
+      team.members.some((member) => member.name === currentUser.name)
+    )
+  }, [teams, currentUser])
+
+  // 현재 유저가 아직 참여하지 않은 팀 목록
+  const availableTeams = useMemo(() => {
+    if (!currentUser) return teams
+    return teams.filter(
+      (team) => !team.members.some((member) => member.name === currentUser.name)
+    )
+  }, [teams, currentUser])
 
   /**
    * [핵심 함수] addLog: 활동 로그 생성
@@ -25,21 +41,31 @@ export const useTeams = (currentUser: CurrentUser | null) => {
    * @param action 발생한 동작 설명
    * @param type 로그의 성격 (default: 일반, info: 정보/변경, success: 완료, error: 반려/에러)
    */
-  const addLog = (ticketId: number, userName: string, action: string, type: 'default' | 'info' | 'success' | 'error' = 'default') => {
-  if (!activeTeamId) return;
-  const time = formatLogTime();
-  setTeams((prev) =>
-    prev.map((t) =>
-      t.id === activeTeamId
-        ? {
-            ...t,
-            // 최신 로그를 맨 위로 올리고, 성능을 위해 최근 20개만 유지
-            logs: [{ id: Date.now(), ticketId, user: userName, action, time, type }, ...t.logs].slice(0, 20),
-          }
-        : t
+  const addLog = (
+    ticketId: number,
+    userName: string,
+    action: string,
+    type: 'default' | 'info' | 'success' | 'error' = 'default'
+  ) => {
+    if (!activeTeamId) return
+
+    const time = formatLogTime()
+
+    setTeams((prev) =>
+      prev.map((t) =>
+        t.id === activeTeamId
+          ? {
+              ...t,
+              // 최신 로그를 맨 위로 올리고, 성능을 위해 최근 20개만 유지
+              logs: [
+                { id: Date.now(), ticketId, user: userName, action, time, type },
+                ...t.logs,
+              ].slice(0, 20),
+            }
+          : t
       )
-    );
-  };
+    )
+  }
 
   /**
    * [기능] updateTicketStatus: 티켓의 진행 상태 변경
@@ -47,31 +73,51 @@ export const useTeams = (currentUser: CurrentUser | null) => {
    * @param newStatus 변경될 상태 (todo, doing, done 등)
    * @param isReject 반려 여부 (true일 경우 빨간색 로그 생성)
    */
-  const updateTicketStatus = (id: number, newStatus: string, isReject = false) => {
-  if (!activeTeamId || !currentUser) return;
-  setTeams((prev) =>
-    prev.map((t) =>
-      t.id === activeTeamId
-        ? { ...t, tickets: t.tickets.map((tk) => (tk.id === id ? { ...tk, status: newStatus } : tk)) }
-        : t
-    )
-  );
-  // 상태 변화에 따른 로그 타입 결정
-  let logType: 'info' | 'success' | 'error' = 'info'; // 기본 파란색
-  if (isReject) logType = 'error'; // 반려 시 빨간색
-  else if (newStatus === 'done') logType = 'success'; // 완료 시 초록색
+  const updateTicketStatus = (
+    id: number,
+    newStatus: string,
+    isReject = false
+  ) => {
+    if (!activeTeamId || !currentUser) return
 
-  addLog(id, currentUser.name, isReject ? '반려 및 재요청' : `상태 변경: ${newStatus}`, logType);
-  };
+    setTeams((prev) =>
+      prev.map((t) =>
+        t.id === activeTeamId
+          ? {
+              ...t,
+              tickets: t.tickets.map((tk) =>
+                tk.id === id ? { ...tk, status: newStatus } : tk
+              ),
+            }
+          : t
+      )
+    )
+
+    // 상태 변화에 따른 로그 타입 결정
+    let logType: 'info' | 'success' | 'error' = 'info'
+    if (isReject) logType = 'error'
+    else if (newStatus === 'done') logType = 'success'
+
+    addLog(
+      id,
+      currentUser.name,
+      isReject ? '반려 및 재요청' : `상태 변경: ${newStatus}`,
+      logType
+    )
+  }
 
   /**
    * [기능] handleCreateTicket: 새로운 업무 요청(티켓) 발행
    */
-const handleCreateTicket = (title: string, content: string, worker: string) => {
-      if (!currentUser || !activeTeamId) {
-      console.error("생성 실패: 유저 정보나 활성화된 팀 ID가 없습니다.");
-      console.log("체크:", { currentUser, activeTeamId });
-      return;
+  const handleCreateTicket = (
+    title: string,
+    content: string,
+    worker: string
+  ) => {
+    if (!currentUser || !activeTeamId) {
+      console.error('생성 실패: 유저 정보나 활성화된 팀 ID가 없습니다.')
+      console.log('체크:', { currentUser, activeTeamId })
+      return
     }
 
     const newTicket: Ticket = {
@@ -81,25 +127,29 @@ const handleCreateTicket = (title: string, content: string, worker: string) => {
       requester: currentUser.name,
       worker,
       status: 'Todo',
-      createdAt: new Date().toLocaleString('ko-KR', { hour12: false }).slice(0, -3),
+      createdAt: new Date()
+        .toLocaleString('ko-KR', { hour12: false })
+        .slice(0, -3),
       comments: [],
-    };
-    
+    }
+
     setTeams((prevTeams) =>
       prevTeams.map((team) =>
         team.id === activeTeamId
           ? { ...team, tickets: [newTicket, ...team.tickets] }
           : team
       )
-    );
-    addLog(newTicket.id, currentUser.name, `새 업무 발행: ${title}`, 'default');
-  };
+    )
+
+    addLog(newTicket.id, currentUser.name, `새 업무 발행: ${title}`, 'default')
+  }
 
   /**
    * [기능] handleAddComment: 티켓 내 댓글 추가
    */
   const handleAddComment = (ticketId: number, text: string) => {
-    if (!text || !currentUser || !activeTeamId) return;
+    if (!text || !currentUser || !activeTeamId) return
+
     setTeams((prev) =>
       prev.map((t) =>
         t.id === activeTeamId
@@ -110,13 +160,17 @@ const handleCreateTicket = (title: string, content: string, worker: string) => {
                   ? {
                       ...tk,
                       comments: [
-                        ...tk.comments, 
-                        { 
-                          id: Date.now(), 
-                          user: currentUser.name, 
-                          text, 
-                          time: new Date().toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false }) 
-                        }
+                        ...tk.comments,
+                        {
+                          id: Date.now(),
+                          user: currentUser.name,
+                          text,
+                          time: new Date().toLocaleTimeString('ko-KR', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            hour12: false,
+                          }),
+                        },
                       ],
                     }
                   : tk
@@ -124,9 +178,34 @@ const handleCreateTicket = (title: string, content: string, worker: string) => {
             }
           : t
       )
-    );
-    addLog(ticketId, currentUser.name, '댓글 작성', 'info');
-  };
+    )
+
+    addLog(ticketId, currentUser.name, '댓글 작성', 'info')
+  }
+
+  /**
+   * [기능] leaveTeam: 현재 유저를 팀 멤버 목록에서 제거
+   */
+  const leaveTeam = (teamId: string) => {
+    if (!currentUser) return
+
+    setTeams((prev) =>
+      prev.map((team) =>
+        team.id === teamId
+          ? {
+              ...team,
+              members: team.members.filter(
+                (member) => member.name !== currentUser.name
+              ),
+            }
+          : team
+      )
+    )
+
+    if (activeTeamId === teamId) {
+      setActiveTeamId(null)
+    }
+  }
 
   // 외부 컴포넌트에서 사용할 데이터와 함수 반환
   return {
@@ -136,9 +215,12 @@ const handleCreateTicket = (title: string, content: string, worker: string) => {
     activeTeamId,
     setActiveTeamId,
     activeTeam,
+    joinedTeams,
+    availableTeams,
     addLog,
     updateTicketStatus,
     handleCreateTicket,
     handleAddComment,
-  };
-};
+    leaveTeam,
+  }
+}

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -3,18 +3,19 @@
  * @description 가입된 팀과 가입 가능한 팀을 구분하여 보여주며, 실시간 검색 및 새 팀 개설 기능을 제공합니다.
  */
 
-import { useState } from 'react';
-import { Search, PlusCircle, LogOut, Users, X } from 'lucide-react';
-import type { Team, CurrentUser } from '../types';
+import { useState } from "react";
+import { Search, PlusCircle, LogOut, Users, X } from "lucide-react";
+import type React from "react";
+import type { Team, CurrentUser } from "../types";
 
 interface LobbyProps {
-  teams: Team[];                    // 전체 프로젝트(팀) 배열
-  currentUser: CurrentUser;          // 현재 접속한 사용자 정보
-  setCurrentUser: (user: null) => void; // 시스템 로그아웃 함수
+  teams: Team[]; // 전체 프로젝트(팀) 배열
+  currentUser: CurrentUser; // 현재 접속한 사용자 정보
+  setCurrentUser: React.Dispatch<React.SetStateAction<CurrentUser | null>>; // 시스템 로그아웃 함수
   setActiveTeamId: (id: string) => void; // 클릭한 팀을 활성화하는 함수
-  setIsTeamAuthorized: (auth: boolean) => void; 
+  setIsTeamAuthorized: (auth: boolean) => void;
   setIsCreateTeamModalOpen: () => void; // 새 팀 만들기 모달 열기
-  setIsTeamAuthModalOpen: () => void;   // 비밀번호 인증 모달 열기
+  setIsTeamAuthModalOpen: () => void; // 비밀번호 인증 모달 열기
 }
 
 export const Lobby = ({
@@ -26,70 +27,119 @@ export const Lobby = ({
   setIsTeamAuthModalOpen,
 }: LobbyProps) => {
   // 로비 내 팀 검색을 위한 지역 상태
-  const [teamSearchQuery, setTeamSearchQuery] = useState('');
+  const [teamSearchQuery, setTeamSearchQuery] = useState("");
+
+  // 검색어 정리
+  const normalizedQuery = teamSearchQuery.trim().toLowerCase();
 
   // [Helper] 해당 팀에 내가 이미 멤버로 포함되어 있는지 확인
-  const isMember = (team: Team) => team.members.some((m) => m.name === currentUser.name);
-  
+  const isMember = (team: Team) =>
+    team.members.some((m) => m.name === currentUser.name);
+
   // [Helper] 검색어와 팀 이름이 매칭되는지 확인 (대소문자 무시)
   const matchSearch = (team: Team) =>
-    !teamSearchQuery.trim() || team.name.toLowerCase().includes(teamSearchQuery.trim().toLowerCase());
+    !normalizedQuery || team.name.toLowerCase().includes(normalizedQuery);
+
+  // 검색 결과 먼저 필터링
+  const filteredTeams = teams.filter((team) => matchSearch(team));
 
   // 데이터 분류: 내가 속한 팀 vs 내가 속하지 않은 팀 (검색 필터 적용)
-  const myTeams = teams.filter((t) => isMember(t) && matchSearch(t));
-  const otherTeams = teams.filter((t) => !isMember(t) && matchSearch(t));
+  const myTeams = filteredTeams.filter((t) => isMember(t));
+  const otherTeams = filteredTeams.filter((t) => !isMember(t));
+
+  // 팀 탈퇴 콘솔 확인용
+  const handleLeaveTeam = (team: Team) => {
+    console.log("팀 탈퇴 클릭", {
+      teamId: team.id,
+      teamName: team.name,
+      userName: currentUser.name,
+    });
+  };
 
   /**
    * TeamCard 내부 컴포넌트
    * @description 개별 팀의 정보를 카드 형태로 렌더링합니다.
    */
-  const TeamCard = ({ team }: { team: Team }) => (
+  const TeamCard = ({
+    team,
+    isMyTeam,
+  }: {
+    team: Team;
+    isMyTeam: boolean;
+  }) => (
     <div
       onClick={() => {
         setActiveTeamId(team.id); // 클릭한 팀 ID 저장
         setIsTeamAuthModalOpen(); // 인증 모달(비밀번호 입력) 호출
       }}
-      className="bg-white p-8 rounded-[40px] border-4 border-transparent hover:border-blue-500 hover:shadow-2xl transition-all cursor-pointer group"
+      className="w-full max-w-[320px] rounded-[28px] bg-white px-6 py-6 shadow-sm border border-slate-100 cursor-pointer transition-all hover:shadow-md"
     >
-      <div className="flex items-center gap-5 mb-6">
-        <div className="w-16 h-16 bg-slate-50 rounded-2xl flex items-center justify-center text-3xl shadow-inner group-hover:scale-110 transition-transform">
+      <div className="flex items-start gap-4 mb-5">
+        <div className="w-14 h-14 bg-slate-100 rounded-2xl flex items-center justify-center text-2xl">
           🏢
         </div>
-        <div>
-          <h3 className="text-2xl font-black text-slate-900 leading-tight">{team.name}</h3>
-          <p className="text-xs text-slate-400 font-bold flex items-center gap-1 mt-1">
+
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-lg font-black text-slate-900">
+            {team.name}
+          </h3>
+          <p className="mt-1 flex items-center gap-1 text-[11px] font-semibold text-slate-400">
             <Users size={12} /> {team.members.length}명의 멤버
           </p>
         </div>
       </div>
-      
+
       {/* 카드 footer : 참여 멤버 아바타 미리보기 및 입장 버튼 */}
-      <div className="flex items-center justify-between pt-6 border-t border-slate-50">
-        <div className="flex -space-x-2">
-          {team.members.slice(0, 3).map((m, i) => (
-            <div key={i} className="w-8 h-8 rounded-full border-2 border-white bg-slate-100 flex items-center justify-center text-[10px] font-bold shadow-sm">
-              {m.avatar}
-            </div>
-          ))}
+      <div className="pt-5 border-t border-slate-100 space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex -space-x-2">
+            {team.members.slice(0, 3).map((m, i) => (
+              <div
+                key={i}
+                className="w-7 h-7 rounded-full border-2 border-white bg-slate-100 flex items-center justify-center text-[10px] font-bold shadow-sm"
+              >
+                {m.avatar || m.name.slice(0, 1)}
+              </div>
+            ))}
+          </div>
+
+          <span className="bg-blue-50 text-blue-600 px-4 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest">
+            스페이스 입장
+          </span>
         </div>
-        <span className="bg-blue-50 text-blue-600 px-4 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest group-hover:bg-blue-600 group-hover:text-white transition-colors">
-          스페이스 입장
-        </span>
+
+        {/* 참여 중인 팀만 탈퇴 버튼 노출 */}
+        {isMyTeam && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation(); // 카드 클릭 이벤트 방지
+              handleLeaveTeam(team);
+            }}
+            className="w-full rounded-2xl border border-red-200 bg-red-50 py-2.5 text-xs font-black tracking-widest text-red-500 hover:bg-red-500 hover:text-white transition-colors"
+          >
+            팀 탈퇴
+          </button>
+        )}
       </div>
     </div>
   );
 
   return (
     <div className="min-h-screen bg-slate-50 flex flex-col p-8 text-slate-800">
-      <div className="max-w-4xl w-full mx-auto flex-1 flex flex-col">
-        
+      <div className="max-w-5xl w-full mx-auto flex-1 flex flex-col">
         {/* 상단 헤더: 유저 환영 메시지 및 팀 생성 액션 */}
-        <header className="flex justify-between items-start mb-8">
-          <div className="flex flex-wrap items-end gap-8">
+        <header className="flex justify-between items-start mb-8 gap-6">
+          <div className="flex flex-wrap items-end gap-6">
             <div>
-              <h2 className="text-4xl font-black tracking-tight mb-2">Team Lobby</h2>
-              <p className="text-slate-500 font-bold">{currentUser.name}님, 작업실을 선택하세요.</p>
+              <h2 className="text-4xl font-black tracking-tight mb-2">
+                Team Lobby
+              </h2>
+              <p className="text-slate-500 font-bold">
+                {currentUser.name}님, 작업실을 선택하세요.
+              </p>
             </div>
+
             <button
               onClick={setIsCreateTeamModalOpen}
               className="bg-blue-600 hover:bg-blue-700 text-white font-bold px-5 py-2.5 rounded-2xl flex items-center gap-2 shadow-lg transition-all active:scale-95"
@@ -97,6 +147,7 @@ export const Lobby = ({
               <PlusCircle size={18} /> 새 팀 개설하기
             </button>
           </div>
+
           <button
             onClick={() => setCurrentUser(null)}
             className="text-slate-400 hover:text-red-500 font-bold text-xs uppercase tracking-widest flex items-center gap-2 transition-all py-2.5"
@@ -107,16 +158,22 @@ export const Lobby = ({
 
         {/* 실시간 팀 검색 필터 영역 */}
         <div className="relative mb-8">
-          <Search size={20} className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+          <Search
+            size={20}
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
+          />
           <input
             type="text"
             value={teamSearchQuery}
             onChange={(e) => setTeamSearchQuery(e.target.value)}
             placeholder="팀 이름으로 검색..."
-            className="w-full pl-12 pr-6 py-4 bg-white border border-slate-200 rounded-2xl text-slate-800 font-medium outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+            className="w-full pl-12 pr-10 py-4 bg-white border border-slate-200 rounded-2xl text-slate-800 font-medium outline-none focus:ring-2 focus:ring-blue-500 transition-all"
           />
           {teamSearchQuery && (
-            <button onClick={() => setTeamSearchQuery('')} className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 p-1">
+            <button
+              onClick={() => setTeamSearchQuery("")}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 p-1"
+            >
               <X size={18} />
             </button>
           )}
@@ -127,22 +184,37 @@ export const Lobby = ({
           {/* 내가 속한 팀 (섹션 표시 여부를 조건부로 결정) */}
           {myTeams.length > 0 && (
             <section>
-              <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest mb-4">참여 중인 팀</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {myTeams.map((team) => <TeamCard key={team.id} team={team} />)}
+              <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest mb-4">
+                참여 중인 팀
+              </h3>
+              <div className="flex flex-wrap gap-6">
+                {myTeams.map((team) => (
+                  <TeamCard key={team.id} team={team} isMyTeam />
+                ))}
               </div>
             </section>
           )}
-          
+
           {/* 가입 가능한 다른 팀들 */}
-          <section>
-            <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest mb-4">
-              {myTeams.length > 0 ? '입장 가능한 팀' : '팀 목록'}
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {otherTeams.map((team) => <TeamCard key={team.id} team={team} />)}
+          {otherTeams.length > 0 && (
+            <section>
+              <h3 className="text-sm font-black text-slate-400 uppercase tracking-widest mb-4">
+                입장 가능한 팀
+              </h3>
+              <div className="flex flex-wrap gap-6">
+                {otherTeams.map((team) => (
+                  <TeamCard key={team.id} team={team} isMyTeam={false} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* 검색 결과가 없을 때 */}
+          {myTeams.length === 0 && otherTeams.length === 0 && (
+            <div className="bg-white border border-dashed border-slate-200 rounded-4xl p-10 text-center text-slate-400 font-bold">
+              검색 결과가 없습니다.
             </div>
-          </section>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용
- 팀 로비 페이지 UI 구현
- 팀 검색창 구현
- 참여 중인 팀 / 입장 가능한 팀 섹션 분리
- 팀 카드 UI 구현
- 팀 탈퇴 버튼 추가
- 팀 탈퇴 클릭 시 콘솔 확인 기능 추가
- 팀 관련 임시 API 파일 준비

## 참고 사항
- 현재는 프론트 UI 중심 구현입니다.
- 백엔드 API 수신 전이라 teams.ts는 임시 목업 형태로 작성했습니다.