### PR TITLE
[feat_jh/#9] 칸반 보드 ui/ux 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,7 +446,6 @@ export default function App() {
           activeTeam={activeTeam!}
           currentUser={currentUser}
           onClose={() => setSelectedTicketId(null)}
-          updateTicketStatus={updateTicketStatus}
           addComment={(e) => {
             e.preventDefault();
             const formData = new FormData(e.currentTarget);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,6 +182,39 @@ export default function App() {
     setActiveModal(null);
   };
 
+  const handleLeaveTeam = (teamId: string | number | null) => {
+    if (!teamId) return;
+
+    if (!window.confirm("정말 이 팀에서 탈퇴하시겠습니까? 다시 입장하려면 비밀번호가 필요합니다.")) return;
+
+    console.log("탈퇴 시작 - 팀 ID:", teamId); // 디버깅용 로그
+
+    // 전체 팀 목록에서 해당 팀의 '참여 상태'만 업데이트
+    // (참여 중인 팀 목록은 보통 t.isJoined === true 인 것들만 필터링해서 보여주고 계실 거예요)
+    setTeams(prevTeams => 
+      prevTeams.map((t) => 
+        // t.id와 teamId의 타입을 강제로 맞춰서 비교합니다.
+        String(t.id) === String(teamId) 
+          ? { ...t, isJoined: false } 
+          : t
+      )
+    );
+
+    // 현재 활성화된 팀일 경우 로비로 튕겨내기
+    if (String(activeTeamId) === String(teamId)) {
+      console.log("로비로 이동 중...");
+      setIsTeamAuthorized(false);
+      setActiveTeamId(null);
+      // 뷰를 대시보드나 로비로 전환 (필요시 추가)
+      setView('dashboard'); 
+    }
+
+    // 알림창은 모든 처리가 끝난 후 띄우기
+    setTimeout(() => {
+      alert("팀 탈퇴가 완료되었습니다.");
+    }, 100);
+  };
+
   if (!currentUser) {
     return authPage === "login" ? (
       <Login
@@ -281,6 +314,7 @@ export default function App() {
         setActiveTeamId={setActiveTeamId}
         setTeams={setTeams}
         addLog={addLog}
+        onLeaveTeam = {handleLeaveTeam}
       />
 
       <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ interface SidebarProps {
   setActiveTeamId: (id: string | null) => void; // 팀 전환용
   setTeams: React.Dispatch<React.SetStateAction<Team[]>>; // 유저 상태 업데이트 함수
   addLog: (ticketId: number, user: string, action: string, type?: 'default' | 'info' | 'success' | 'error') => void; // 활동 로그 기록 함수
+  onLeaveTeam: (id: string | number) => void; //팀 탈퇴 함수
 }
 
 export const Sidebar = ({ 
@@ -27,7 +28,8 @@ export const Sidebar = ({
   activeTeamId,
   setActiveTeamId,
   setTeams,
-  addLog 
+  addLog,
+  onLeaveTeam
 }: SidebarProps) => {
   // 상태 선택 팝업창의 열림/닫힘 여부
   const [isStatusPickerOpen, setIsStatusPickerOpen] = useState(false);
@@ -37,7 +39,7 @@ export const Sidebar = ({
     label: '활동 중', 
     color: 'bg-green-500' 
   };
-
+  
   return (
     <aside className="w-64 bg-white border-r border-slate-200 flex flex-col shrink-0">
       {/* 상단 로고 및 내비게이션 영역 */}
@@ -139,6 +141,13 @@ export const Sidebar = ({
               setActiveTeamId(null);
               setIsTeamAuthorized(false);
             }}
+            handleLeaveTeam={() => {
+            // activeTeamId가 null일 수도 있으므로 안전하게 처리
+            if (activeTeamId) {
+              onLeaveTeam(activeTeamId); // App.tsx의 handleLeaveTeam 실행
+              setIsStatusPickerOpen(false); // 실행 후 팝업 닫기
+            }
+          }}      
           />
         )}
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'; 
-import { LayoutDashboard, Users, FileText, History, ChevronRight } from 'lucide-react';
+import { LayoutDashboard, Users, FileText, History, ChevronRight, Bell } from 'lucide-react';
 import type { Team, CurrentUser } from '../../types';
 import { StatusBadge } from '../status/StatusBadge';
 import { StatusPicker } from "../status/StatusPicker";
@@ -34,11 +34,18 @@ export const Sidebar = ({
   // 상태 선택 팝업창의 열림/닫힘 여부
   const [isStatusPickerOpen, setIsStatusPickerOpen] = useState(false);
 
+  // Sidebar 컴포넌트 내부 상단에 추가
+  const [activeLogTab, setActiveLogTab] = useState<'all' | 'mine'>('all');
   // 내 현재 상태 정보 가져오기 (기본값: 활동 중)
   const myStatus = activeTeam.userStatuses[currentUser.name] || { 
     label: '활동 중', 
     color: 'bg-green-500' 
   };
+
+  // 탭에 따른 로그 필터링
+  const filteredLogs = activeLogTab === 'all' 
+    ? activeTeam.logs 
+    : activeTeam.logs.filter(log => log.user === currentUser.name);
   
   return (
     <aside className="w-64 bg-white border-r border-slate-200 flex flex-col shrink-0">
@@ -68,17 +75,34 @@ export const Sidebar = ({
 
       {/* 히스토리 로그 영역 */}
       <div className="px-4 mb-4 shrink-0">
-        <div className="bg-slate-50/80 rounded-2xl border border-slate-100 p-3">
-          <div className="flex items-center gap-2 mb-3 px-1">
+      <div className="bg-slate-50/80 rounded-2xl border border-slate-100 p-3">
+        {/* 로그 헤더: 로고와 탭 전환 버튼 */}
+        <div className="flex items-center justify-between mb-3 px-1">
+          <div className="flex items-center gap-2">
             <History size={14} className="text-blue-500" />
             <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Log</span>
           </div>
           
+          <div className="flex bg-slate-200/50 p-0.5 rounded-lg">
+            <button 
+              onClick={() => setActiveLogTab('all')}
+              className={`text-[9px] px-2 py-1 rounded-md transition-all font-bold ${activeLogTab === 'all' ? 'bg-white text-blue-600 shadow-sm' : 'text-slate-400'}`}
+            >
+              로그
+            </button>
+            <button 
+              onClick={() => setActiveLogTab('mine')}
+              className={`text-[9px] px-2 py-1 rounded-md transition-all font-bold ${activeLogTab === 'mine' ? 'bg-white text-blue-600 shadow-sm' : 'text-slate-400'}`}
+            >
+              내 소식
+            </button>
+          </div>
+        </div>
+          
           {/* 로그 리스트 */}
-          <div className="space-y-3 max-h-35 overflow-y-auto pr-1 scrollbar-hide">
-            {activeTeam.logs.map((log) => {
-              console.log("로그 타입 확인:", log.type);
-              // 로그 타입별 색상 매핑
+          <div className="space-y-3 max-h-40 overflow-y-auto pr-1 scrollbar-hide min-h-40">
+          {filteredLogs.length > 0 ? (
+            filteredLogs.map((log) => {
               const logStyles = {
                 default: { dot: 'bg-slate-400', border: 'border-slate-200', text: 'text-slate-500', bg: '' },
                 info: { dot: 'bg-blue-500', border: 'border-blue-200', text: 'text-blue-600', bg: 'bg-blue-50/30' },
@@ -104,7 +128,14 @@ export const Sidebar = ({
                   </p>
                 </div>
               );
-            })}
+            })
+            ) : (
+              <div className="h-full flex flex-col items-center justify-center py-8 text-slate-300">
+                <Bell size={20} className="mb-2 opacity-20" />
+                <p className="text-[10px] font-medium">새로운 소식이 없습니다.</p>
+              </div>
+            )
+            }
           </div>
         </div>
       </div>

--- a/src/components/status/StatusPicker.tsx
+++ b/src/components/status/StatusPicker.tsx
@@ -1,23 +1,34 @@
-import { LogOut } from 'lucide-react';
+import { LogOut, UserMinus } from 'lucide-react';
 import { USER_ACTIVITIES } from '../../utils/constants';
 
 interface StatusPickerProps {
   currentStatusLabel: string; // 현재 적용되어 있는 내 상태 라벨
   onStatusChange: (activity: typeof USER_ACTIVITIES[0]) => void; // 상태 클릭 시 변경 핸들러
   onLogout: () => void; // 로그아웃 클릭 시 실행될 핸들러
+  handleLeaveTeam: () => void; // 팀 탈퇴 핸들러
 }
 
-export const StatusPicker = ({ currentStatusLabel, onStatusChange, onLogout }: StatusPickerProps) => {
+export const StatusPicker = ({ currentStatusLabel, onStatusChange, onLogout, handleLeaveTeam }: StatusPickerProps) => {
   return (
     // 사이드바 하단 프로필 위에 떠야 하므로 absolute와 bottom-full 적용
     <div className="absolute bottom-full left-4 right-4 mb-2 bg-white rounded-2xl shadow-2xl border border-slate-200 p-2 z-50">
+      {/* 팀 탈퇴 버튼 */}
+        <button
+          onClick={handleLeaveTeam}
+          className="w-full flex items-center gap-2 px-3 py-2 text-xs font-bold text-red-500 hover:bg-red-50 hover:text-red-600 rounded-xl transition-all"
+        >
+          <UserMinus size={14} /> 팀 탈퇴하기
+        </button>
+
       {/* 로그아웃 버튼 (상단 구분선 포함) */}
       <button
         onClick={onLogout}
-        className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-xs font-bold text-red-500 hover:bg-red-50 transition-colors mb-2 border-b border-slate-50"
+        className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-xs font-bold  text-slate-600 hover:bg-slate-50  mb-2"
       >
         <LogOut size={14} /> 시스템 로그아웃
       </button>
+
+      <div className="my-1.5 border-t border-slate-200/60 mx-2" />
 
       {/* 상태 선택 리스트 */}
       <div className="space-y-1">

--- a/src/components/task/KanbanBoard.tsx
+++ b/src/components/task/KanbanBoard.tsx
@@ -1,4 +1,3 @@
-import { Plus } from 'lucide-react';
 import type { Ticket, StatusType } from '../../types';
 import { TicketCard } from './TicketCard';
 
@@ -6,11 +5,10 @@ interface KanbanColumnProps {
   status: StatusType; // 컬럼의 상태 정보 (ID, 라벨, 아이콘, 색상 등 포함)
   tickets: Ticket[]; // 이 컬럼의 상태와 일치하도록 부모(Dashboard)에서 필터링되어 넘어온 티켓들
   onTicketClick: (id: number) => void; // 티켓 클릭 시 상세 모달을 띄우기 위한 핸들러
-  onAddTicketClick: () => void; // 하단 '새로운 요청 추가' 버튼 클릭 핸들러
   updateTicketStatus: (id: number, newStatus: string, isReject?: boolean) => void; // 티켓 상태 변경(반려 포함) 로직
 }
 
-export const KanbanColumn = ({ status, tickets, onTicketClick, onAddTicketClick, updateTicketStatus }: KanbanColumnProps) => {
+export const KanbanColumn = ({ status, tickets, onTicketClick, updateTicketStatus }: KanbanColumnProps) => {
   // 상태 정보에서 아이콘 컴포넌트를 추출
   const Icon = status.icon;
 
@@ -38,14 +36,6 @@ export const KanbanColumn = ({ status, tickets, onTicketClick, onAddTicketClick,
             updateTicketStatus={updateTicketStatus}
           />
         ))}
-
-        {/* 하단 추가 버튼 */}
-        <button
-          onClick={onAddTicketClick}
-          className="w-full py-4 bg-white/40 border-2 border-dashed border-slate-200 rounded-[28px] text-slate-400 font-bold text-xs hover:border-blue-300 hover:text-blue-500 hover:bg-white transition-all flex items-center justify-center gap-2 shrink-0"
-        >
-          <Plus size={16} /> 새로운 요청 추가
-        </button>
       </div>
     </div>
   );

--- a/src/components/task/TicketDetail.tsx
+++ b/src/components/task/TicketDetail.tsx
@@ -1,22 +1,32 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { X, Clock, ArrowRight, Send } from 'lucide-react';
 import type { Ticket, Team, CurrentUser } from '../../types';
-import { STATUS_TYPES } from '../../utils/constants';
 
 interface TicketDetailProps {
   ticket: Ticket;
   activeTeam: Team;
   currentUser: CurrentUser;
   onClose: () => void; // 모달 닫기 함수
-  updateTicketStatus: (id: number, newStatus: string) => void; // 상태 변경 함수
   addComment: (e: React.FormEvent<HTMLFormElement>) => void; // 댓글 등록 함수
 }
 
-export const TicketDetail = ({ ticket, activeTeam, onClose, updateTicketStatus, addComment }: TicketDetailProps) => {
+export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComment }: TicketDetailProps) => {
+  // 스크롤 위치를 잡기 위한 Ref 생성
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // 2. 스크롤 하단 이동 함수
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  // 3. 댓글 데이터(ticket.comments)가 변경될 때마다 함수 실행
+  useEffect(() => {
+    scrollToBottom();
+  }, [ticket.comments]);
   return (
     // 고정된 전체 화면 오버레이 (Backdrop)
     <div className="fixed inset-0 z-100 flex items-center justify-center bg-slate-900/60 backdrop-blur-md p-4">
-      <div className="bg-white w-full max-w-xl rounded-[48px] shadow-2xl overflow-hidden flex flex-col max-h-[90vh]">
+      <div className="bg-white w-full max-w-xl rounded-[48px] shadow-2xl overflow-hidden flex flex-col max-h-[90vh] h-[70vh]">
 
         {/* 헤더 섹션: 제목 및 닫기 버튼 */}
         <header className="p-8 flex justify-between items-start shrink-0">
@@ -57,31 +67,48 @@ export const TicketDetail = ({ ticket, activeTeam, onClose, updateTicketStatus, 
               </div>
             </div>
           </div>
-
-          {/* 진행 상태 변경 섹션 */}
-          <div className="space-y-4">
-            <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest ml-1">진행 상태 변경</p>
-            <div className="grid grid-cols-2 gap-3">
-              {STATUS_TYPES.map((s) => (
-                <button key={s.id} onClick={() => updateTicketStatus(ticket.id, s.id)} className={`flex items-center gap-3 p-4 rounded-2xl border-2 transition-all font-bold text-xs ${ticket.status === s.id ? 'border-blue-600 bg-blue-50 text-blue-600 shadow-lg shadow-blue-100' : 'border-slate-50 bg-slate-50/50 text-slate-400 hover:border-slate-200'}`}>
-                  <s.icon size={16} className="shrink-0" /> {s.label}
-                </button>
-              ))}
-            </div>
-          </div>
+          
 
           {/* 댓글 섹션 */}
+          <div className="space-y-6"> {/* 간격을 조금 더 넓혔어요 */}
+          <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest ml-1">커뮤니케이션</p>
+          
           <div className="space-y-4">
-            <p className="text-[10px] font-black text-slate-400 uppercase tracking-widest ml-1">커뮤니케이션</p>
-            <div className="space-y-4">
-              {ticket.comments.map((c) => (
-                <div key={c.id} className="flex gap-3">
-                  <div className="w-8 h-8 rounded-full bg-slate-200 flex items-center justify-center text-[10px] font-bold text-white shrink-0">{c.user[0]}</div>
-                  <div className="flex-1 bg-slate-50 p-4 rounded-2xl rounded-tl-none text-xs text-slate-600 leading-relaxed min-w-0">{c.text}</div>
+            {ticket.comments.map((c) => {
+              // 1. 내가 쓴 글인지 판단하는 변수
+              const isMe = c.user === currentUser.name;
+
+              return (
+                <div 
+                  key={c.id} 
+                  // 2. 내가 쓴 글이면 flex-row-reverse를 적용해 아바타를 오른쪽으로 보냅니다.
+                  className={`flex gap-3 ${isMe ? 'flex-row-reverse' : 'flex-row'}`}
+                >
+                  {/* 아바타: 내 아바타는 파란색으로 강조 */}
+                  <div className={`w-8 h-8 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0 ${
+                    isMe ? 'bg-blue-600 shadow-md shadow-blue-100' : 'bg-slate-200'
+                  }`}>
+                    {c.user[0]}
+                  </div>
+
+                  {/* 메시지 박스: 내 메시지는 말풍선 꼬리 방향을 오른쪽(rounded-tr-none)으로! */}
+                  <div className={`max-w-[75%] p-4 rounded-2xl text-xs leading-relaxed ${
+                    isMe 
+                      ? 'bg-blue-600 text-white rounded-tr-none shadow-sm' // 내 메시지 (파란색)
+                      : 'bg-slate-50 text-slate-600 rounded-tl-none border border-slate-100' // 상대방 (회색)
+                  }`}>
+                    {/* 3. 내가 쓴 글이 아닐 때만 이름을 표시하고 싶다면 추가 (선택 사항) */}
+                    {!isMe && <p className="text-[9px] font-black mb-1 opacity-60">{c.user}</p>}
+                    {c.text}
+                  </div>
                 </div>
-              ))}
-            </div>
+              );
+            })}
+
+            {/* 스크롤 하단 이동 지점 */}
+            <div ref={messagesEndRef} />
           </div>
+        </div>
         </div>
         
         {/* 푸터 섹션: 댓글 입력 폼 */}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { X } from 'lucide-react';
 
 interface ModalProps {
   isOpen: boolean;
@@ -22,10 +23,16 @@ export const Modal = ({ isOpen, onClose, title, children, maxWidth = 'max-w-lg' 
       <div className={`bg-white w-full ${maxWidth} rounded-[48px] shadow-2xl p-10 relative z-10 overflow-hidden flex flex-col max-h-[90vh]`}>
         
         {/* 모달 헤더 섹션: 제목 */}
-        <header className="p-6 border-b border-slate-50">
+        <header className="p-6 flex justify-between items-center border-b border-slate-50">
           <h3 className="text-lg font-black text-slate-800 uppercase tracking-tight text-center">
             {title}
           </h3>
+          <button 
+            onClick={onClose} 
+            className="p-2 hover:bg-slate-100 rounded-full text-slate-400 transition-colors"
+          >
+            <X size={20} />
+          </button>
         </header>
 
         {/* 모달 내부 콘텐츠 */}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,30 @@ export const Dashboard = ({
   setSelectedTicketId, 
   updateTicketStatus 
 }: DashboardProps) => {
+
+  // 전체 티켓이 하나도 없는지 확인
+  const isEmpty = activeTeam.tickets.length === 0;
+
+  if (isEmpty) {
+    return (
+      <div className="h-full w-full flex flex-col items-center justify-center p-8 animate-in fade-in duration-500">
+        <div className="text-center space-y-3 mb-10">
+          <p className="text-slate-400 font-medium text-2xl whitespace-pre-wrap">
+            { "팀원들과 빠르게 \n 업무 요청을 해보세요!" }
+          </p>
+        </div>
+
+        {/* 새 요청 추가 버튼 */}
+        <button
+          onClick={setIsCreateModalOpen}
+          className="group bg-blue-600 hover:bg-blue-700 text-white px-30 py-5 rounded-4xl font-black flex items-center gap-3 shadow-2xl shadow-blue-200 transition-all active:scale-95 text-xl" 
+        >
+          새 요청
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex gap-6 h-full min-w-300">
       {/* 
@@ -31,8 +55,7 @@ export const Dashboard = ({
             status={status}
             tickets={filteredTickets}
             onTicketClick={setSelectedTicketId}
-            onAddTicketClick={setIsCreateModalOpen}
-            updateTicketStatus={updateTicketStatus}
+            updateTicketStatus={updateTicketStatus} 
           />
         );
       })}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,7 +87,7 @@ export interface CurrentUser extends Member {}
 export interface StatusType {
   id: string;
   label: string;
-icon: typeof Circle; // Lucide 아이콘 컴포넌트 타입
+  icon: typeof Circle; // Lucide 아이콘 컴포넌트 타입
   color: string;      // 아이콘 및 텍스트 색상 (Tailwind)
   border: string;     // 컬럼/카드 테두리 색상
   bg: string;         // 배경색

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -102,8 +102,7 @@ export const INITIAL_TEAM: Team = {
     {
       id: 1, // DB의 PK와 매칭됨
       title: 'API 명세서 수정 요청',
-      content:
-        '로그인 시 반환되는 JWT 토큰에 유저 권한 정보 추가가 필요합니다.',
+      content: '로그인 시 반환되는 JWT 토큰에 유저 권한 정보 추가가 필요합니다.',
       requester: '영아',
       worker: '민수',
       status: 'Doing',
@@ -111,13 +110,13 @@ export const INITIAL_TEAM: Team = {
       comments: [
         {
           id: 101,
-          user: '민수', 
+          user: '민수',
           text: '네, 확인했습니다. 해당 정보는 payload에 담아드리면 될까요?',
           time: '2026.03.11 10:05',
         },
         {
           id: 102,
-          user: '영아', 
+          user: '영아',
           text: '네, 맞습니다! 권한 코드(role) 형태로 부탁드려요.',
           time: '2026.03.11 10:10',
         },
@@ -154,8 +153,7 @@ export const INITIAL_TEAM: Team = {
     {
       id: 1,
       title: '주간 회의록 (03.11)',
-      content:
-        '### 결정 사항\n- MVP 기능 확정\n- 이번주 UI 완성',
+      content: '### 결정 사항\n- MVP 기능 확정\n- 이번주 UI 완성',
       author: '영아',
       date: '2026.03.11',
     },
@@ -173,4 +171,5 @@ export const INITIAL_TEAM: Team = {
     민수: { label: '회의 중', color: 'bg-blue-500' },
     지수: { label: '자리 비움', color: 'bg-slate-300' },
   },
+  isJoined: false
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -108,7 +108,26 @@ export const INITIAL_TEAM: Team = {
       worker: '민수',
       status: 'Doing',
       createdAt: '2026.03.11 10:00',
-      comments: [],
+      comments: [
+        {
+          id: 101,
+          user: '민수', 
+          text: '네, 확인했습니다. 해당 정보는 payload에 담아드리면 될까요?',
+          time: '2026.03.11 10:05',
+        },
+        {
+          id: 102,
+          user: '영아', 
+          text: '네, 맞습니다! 권한 코드(role) 형태로 부탁드려요.',
+          time: '2026.03.11 10:10',
+        },
+        {
+          id: 103,
+          user: '민수',
+          text: '알겠습니다. 오늘 오후 중으로 수정해서 배포해둘게요.',
+          time: '2026.03.11 10:15',
+        }
+      ],
     },
     {
       id: 2,


### PR DESCRIPTION
칸반 보드 탭
- [x]  칸반 보드 empty 추가
- [x] 새로운 요청 추가 버튼 제거

사이드바
- [x] 상태 리스트 -> 로그아웃 아래 팀 탈퇴 버튼 추가
- [x] 팀 탈퇴 버튼 클릭 시, 팀 로비로 이동

로그
- [x] 내 소식 탭 추가
<img width="1710" height="1073" alt="스크린샷 2026-03-19 오후 9 27 30" src="https://github.com/user-attachments/assets/cdd6e4cc-9446-4a58-9957-7cd885f7844d" />

-----------

새로운 요청 발행 모달
- [x]  뒤로가기 버튼 추가
<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/b594feaf-dac7-4797-81fa-12a7f998274e" />

------------

칸반 카드
- [x]  카테고리 삭제 후, 커뮤니케이션 위치 조정
- [x]  커뮤니케이션 댓글 달리면 자동 스크롤 
- [x] 상대방 메세지는 왼쪽, 내 메세지는 오른쪽
<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/589de47e-ae83-4f64-b744-f38ee140bd39" />
<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/47d9e985-4063-4890-a1fc-545b75b922f5" />