### PR TITLE
[Feat] 팀 탈퇴 API 연결 및 phone 필드 반영 (#42)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,6 +173,7 @@ export default function App() {
             name: user.name || 'Unknown',
             avatar: user.avatar || '',
             email: user.email || '',
+            phone: user.phone || '',
             position: user.position || '팀원',
             github: user.github || '',
           });
@@ -180,7 +181,7 @@ export default function App() {
           const wasAuthorized = localStorage.getItem('isTeamAuthorized') === 'true';
           if (lastTeamId && wasAuthorized) {
             setActiveTeamId(lastTeamId);
-            setIsTeamAuthorized(true); // ← 이게 없어서 Sidebar가 렌더링되는데 activeTeam이 null인 거예요
+            setIsTeamAuthorized(true); 
           }
         }
       } catch (error) {

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -1,6 +1,5 @@
 import { api } from './client'
-import type { GetTeamsResponse, CreateTeamRequest, CreateTeamResponse, JoinTeamRequest, JoinTeamResponse } from '../types'
-
+import type { GetTeamsResponse, CreateTeamRequest, CreateTeamResponse, JoinTeamRequest, JoinTeamResponse, LeaveTeamResponse } from '../types'
 // GET /teams - 팀 목록 전체 조회
 export const getTeamsApi = async (): Promise<GetTeamsResponse> => {
   const res = await api.get('/teams')
@@ -21,5 +20,11 @@ export const joinTeamApi = async (
   data: JoinTeamRequest
 ): Promise<JoinTeamResponse> => {
   const res = await api.post(`/teams/${teamId}/members`, data)
+  return res.data
+}
+
+// DELETE /teams/{teamId}/members/me - 팀 탈퇴
+export const leaveTeamApi = async (teamId: number): Promise<LeaveTeamResponse> => {
+  const res = await api.delete(`/teams/${teamId}/members/me`)
   return res.data
 }

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -22,6 +22,7 @@ const convertTeam = (team: TeamFromApi): Team => ({
     position: m.position,
     avatar: m.user.profile_image || AVATARS[Math.floor(Math.random() * AVATARS.length)],
     email: m.user.email,
+    phone: m.user.phone,
     github: m.user.github_url || '',
   })),
   tickets: [],

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -3,9 +3,10 @@
  * @description 가입된 팀과 가입 가능한 팀을 구분하여 보여주며, 실시간 검색 및 새 팀 개설 기능을 제공합니다.
  */
 import { useState } from "react";
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 import { Search, PlusCircle, LogOut, Users, X, DoorOpen } from "lucide-react";
-import { getTeamsApi } from '../api/team'
+import { getTeamsApi, leaveTeamApi } from '../api/team'
 import { AVATARS } from '../utils/constants'
 import type { Team, TeamFromApi, CurrentUser } from "../types";
 
@@ -30,6 +31,7 @@ const convertTeam = (team: TeamFromApi): Team => ({
     position: m.position,
     avatar: m.user.profile_image || AVATARS[Math.floor(Math.random() * AVATARS.length)],
     email: m.user.email,
+    phone: m.user.phone,
     github: m.user.github_url || '',
   })),
   tickets: [],
@@ -53,6 +55,24 @@ export const Lobby = ({
 }: LobbyProps) => {
   // 로비 내 팀 검색을 위한 지역 상태
   const [teamSearchQuery, setTeamSearchQuery] = useState("");
+
+  // React Query 캐시 제어용
+  const queryClient = useQueryClient();
+
+  // DELETE /teams/{teamId}/members/me 팀 탈퇴 API 호출
+  const leaveTeamMutation = useMutation({
+    mutationFn: (teamId: number) => leaveTeamApi(teamId),
+
+    // 탈퇴 성공 시 팀 목록 다시 조회
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['teams'] })
+    },
+
+    // 탈퇴 실패 시 에러 메시지 출력
+    onError: (error: AxiosError<{ error?: string }>) => {
+      alert(error.response?.data?.error || '팀 탈퇴에 실패했습니다.')
+    },
+  })
 
   // GET /teams API 호출
   const { data, isLoading, isError } = useQuery({
@@ -83,13 +103,9 @@ export const Lobby = ({
   const myTeams = filteredTeams.filter((t) => isMember(t));
   const otherTeams = filteredTeams.filter((t) => !isMember(t));
 
-  // 팀 탈퇴 콘솔 확인용
+  // 팀 탈퇴 버튼 클릭 시 해당 팀 탈퇴 API 호출
   const handleLeaveTeam = (team: Team) => {
-    console.log("팀 탈퇴 클릭", {
-      teamId: team.id,
-      teamName: team.name,
-      userName: currentUser.name,
-    });
+    leaveTeamMutation.mutate(Number(team.id));
   };
 
   // 로딩 중 화면

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Member {
   position: string;
   avatar?: string;
   email: string;
+  phone: string;
   github: string;
 }
 
@@ -157,6 +158,16 @@ export interface JoinTeamRequest {
 
 // POST /teams/{teamId}/members 응답 타입
 export interface JoinTeamResponse {
+  success: boolean;
+  data: {
+    message: string;
+  } | null;
+  meta: null;
+  error: string | null;
+}
+
+// DELETE /teams/{teamId}/members/me 응답 타입
+export interface LeaveTeamResponse {
   success: boolean;
   data: {
     message: string;


### PR DESCRIPTION
## 작업 내용

- DELETE /teams/{teamId}/members/me 팀 탈퇴 API 연결
- 팀 탈퇴 성공 시 팀 목록 재조회 처리
- GET /teams 응답의 phone 필드 프론트 반영
- Lobby.tsx convertTeam에 phone 필드 추가
- useTeams.ts convertTeam에 phone 필드 추가
- Member 타입(phone) 반영

## 확인 내용

- 팀 탈퇴 API 200 응답 확인
- 탈퇴 후 팀 목록에서 제거되는 것 확인
- GET /teams 응답에서 phone 데이터 수신 확인
- 프론트에서 phone 데이터 정상 매핑 확인

## 참고 사항

- 팀 삭제 API는 없으며, 마지막 팀원이 탈퇴 시 자동 삭제되는 구조입니다.
- 팀 리더 권한은 현재 고려하지 않는 구조입니다.