### PR TITLE
[jh_bug/#49] 랜더링 이슈 및 task 상세 번호 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,8 @@ export default function App() {
     activeTeamId,
     setActiveTeamId,
     activeTeam,
+    pendingTeamId, 
+    setPendingTeamId,
     updateTicketStatus,
     handleAddComment,
     addLog,
@@ -164,13 +166,24 @@ export default function App() {
         setAuthError(data.error || '비밀번호가 일치하지 않습니다.');
         return;
       }
+
+      // 인증 성공 시, 대기 중이던 ID를 활성 ID로 설정
+      // useTeams의 useQuery가 작동하여 테스크 목록 호출
+      if (pendingTeamId) {
+        setActiveTeamId(pendingTeamId);
+
+        addLog(0, currentUser!.name, '공간 입장', 'info', pendingTeamId);
+      }
+
       queryClient.invalidateQueries({ queryKey: ['teams'] });
       setIsTeamAuthorized(true);
+      localStorage.setItem('isTeamAuthorized', 'true');
       setActiveModal(null);
       setAuthPassword(Array(6).fill(''));
       setAuthError('');
       setAuthCursorIndex(0);
       setShowAuthPassword(false);
+      setPendingTeamId(null); // 인증 후에는 pendingTeamId 초기화
       addLog(0, currentUser!.name, '공간 입장', 'info');
     },
     onError: () => {
@@ -342,9 +355,9 @@ export default function App() {
   // 팀 인증 (Lobby 전용)
   const handleTeamAuth = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!activeTeamId || !isAuthPasswordComplete) return;
+    if (!pendingTeamId || !isAuthPasswordComplete) return;
     joinTeamMutation.mutate({
-      teamId: activeTeamId,
+      teamId: pendingTeamId,
       data: {
         password: authPassword.join(''),
         userId: Number(currentUser!.id) || 0,
@@ -515,7 +528,7 @@ export default function App() {
         <Lobby
           currentUser={currentUser}
           onLogout={handleLogout}
-          setActiveTeamId={setActiveTeamId}
+          setPendingTeamId={setPendingTeamId}
           setIsTeamAuthorized={setIsTeamAuthorized}
           setIsCreateTeamModalOpen={() => setActiveModal('createTeam')}
           setIsTeamAuthModalOpen={() => setActiveModal('auth')}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createTeamApi, joinTeamApi } from './api/team';
 import { type JoinTeamRequest } from './types';
 import { Eye, EyeOff, Trash2 } from 'lucide-react';
@@ -192,23 +192,27 @@ export default function App() {
   });
 
   // 세션 복원 로직
+  const { data: userData, isLoading: isUserLoading } = useQuery({
+    queryKey: ['myInfo'],
+    queryFn: getMyInfoApi,
+    staleTime: Infinity, // 앱이 켜져 있는 동안은 다시 부르지 않음 (중복 호출 방지)
+    gcTime: Infinity,
+    retry: false,        // 로그인 안 되어 있을 때 반복 호출 방지
+  });
+
   useEffect(() => {
-    const restoreSession = async () => {
-      console.log('로그인 한 유저 정보 복원 시도 ..');
-      try {
-        const user = await getMyInfoApi();
-        console.log('로그인 한 유저 정보 복원 성공:', user);
-        if (user) {
+        if (userData) {
           setCurrentUser({
-            id: user.id || Date.now(),
-            uuid: user.uuid,
-            name: user.name || 'Unknown',
-            avatar: user.avatar || '',
-            email: user.email || '',
-            phone: user.phone || '',
-            position: user.position || '팀원',
-            github: user.github || '',
+            id: userData.id || Date.now(),
+            uuid: userData.uuid,
+            name: userData.name || 'Unknown',
+            avatar: userData.avatar || '',
+            email: userData.email || '',
+            phone: userData.phone || '',
+            position: userData.position || '팀원',
+            github: userData.github || '',
           });
+
           const lastTeamId = localStorage.getItem('lastTeamId');
           const wasAuthorized =
             localStorage.getItem('isTeamAuthorized') === 'true';
@@ -217,15 +221,10 @@ export default function App() {
             setIsTeamAuthorized(true);
           }
         }
-      } catch (error) {
-        console.log('로그인 한 유저 정보 복원 실패:', error);
-      } finally {
-        console.log('로딩 해제');
-        setIsAuthLoading(false);
-      }
-    };
-    restoreSession();
-  }, [setActiveTeamId]);
+    if (!isUserLoading) {
+      setIsAuthLoading(false);
+    }
+  }, [userData, isUserLoading, setActiveTeamId]);
 
   // --- 세션 유지 로직 ---
   useEffect(() => {

--- a/src/components/task/TicketDetail.tsx
+++ b/src/components/task/TicketDetail.tsx
@@ -14,7 +14,7 @@ interface TicketDetailProps {
   handleDeleteTicketApi: (ticketId: number) => Promise<{ ok: boolean; message?: string }>;
 }
 
-export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComment, setTeams, activeTeamId, addLog, handleDeleteTicketApi }: TicketDetailProps) => {
+export const TicketDetail = ({ ticket, currentUser, onClose, addComment, setTeams, activeTeamId, addLog, handleDeleteTicketApi }: TicketDetailProps) => {
   // 스크롤 위치를 잡기 위한 Ref 생성
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -86,7 +86,7 @@ export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComm
         <header className="p-8 flex justify-between items-start shrink-0">
           <div className="flex items-center gap-4 min-w-0">
             <div className="w-14 h-14 bg-blue-600 rounded-2xl flex items-center justify-center text-white font-black text-2xl shadow-xl shadow-blue-200 shrink-0">
-              #{ticket.id || activeTeam.tickets.indexOf(ticket) + 1}
+              #{ticket.task_number}
             </div>
             <div className="min-w-0">
               <h3 className="text-2xl font-black text-slate-900 leading-tight truncate">

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -63,9 +63,7 @@ export const useTeams = (currentUser: CurrentUser | null) => {
   const [localTeams, setTeams] = useState<Team[]>([INITIAL_TEAM])
 
   // 새로고침 시, 로컬스토리지에 저장된 팀 ID를 가져오기
-  const [activeTeamId, setActiveTeamId] = useState<string | null>(() => {
-    return localStorage.getItem('lastActiveTeamId');
-  });
+  const [activeTeamId, setActiveTeamId] = useState<string | null>(null);
 
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
 
@@ -74,13 +72,6 @@ export const useTeams = (currentUser: CurrentUser | null) => {
     queryFn: () => getTicketDetailApi(selectedTicketId!),
     enabled: !!selectedTicketId,
   });
-
-  // activeTeamId가 바뀔 때마다 localStorage에 저장
-  useEffect(() => {
-    if (activeTeamId) {
-      localStorage.setItem('lastActiveTeamId', activeTeamId);
-    }
-  }, [activeTeamId]);
 
   // GET /teams API 호출로 팀 목록 가져오기
   const { data: teamListData } = useQuery({
@@ -112,7 +103,7 @@ export const useTeams = (currentUser: CurrentUser | null) => {
                 content: d.content,
                 // 서버 응답의 comments 구조를 UI 규격에 맞게 매핑
                 comments: d.comments.map((c: any) => ({
-                  id: c.id,
+                  task_number: d.task_number,
                   user: c.user.name,
                   text: c.content,
                   time: new Date(c.created_at).toLocaleTimeString()
@@ -146,11 +137,12 @@ export const useTeams = (currentUser: CurrentUser | null) => {
 
   // 선택된 팀의 티켓 데이터를 localTeams에 추가
   useEffect(() => {
-    if (ticketData?.success && activeTeamId && localTeams.length > 1) {
+    if (ticketData?.success && activeTeamId) {
       // 현재 활성화된 팀 '멤버 리스트' 가져오기
       const currentTeam = localTeams.find(t => String(t.id) === String(activeTeamId));
-      const currentMembers = currentTeam?.members || [];
+      if (!currentTeam) return;
 
+      const currentMembers = currentTeam?.members || [];
       const serverTasks = ticketData.data.tasks.map((task: any) => {
         // worker_id(UUID)와 일치하는 담당자 찾기
         const matchedMember = currentMembers.find(m => String(m.uuid) === String(task.worker_id));
@@ -160,6 +152,7 @@ export const useTeams = (currentUser: CurrentUser | null) => {
         
         return {
           id: task.id,
+          task_number: task.task_number,
           title: task.title,
           content: task.content,
           status: task.status || 'Todo',
@@ -172,21 +165,17 @@ export const useTeams = (currentUser: CurrentUser | null) => {
       });
 
       setTeams(prev => {
-        // 현재 팀 리스트에 해당 팀이 있는지 확인
-        const teamExists = prev.some(t => String(t.id) === String(activeTeamId));
-        
-        if (!teamExists) return prev;
+        const targetTeam = prev.find(t => String(t.id) === String(activeTeamId));
+        const isSame = JSON.stringify(targetTeam?.tickets) === JSON.stringify(serverTasks);
+      
+        if (isSame) return prev; 
 
         return prev.map(team => 
-          String(team.id) === String(activeTeamId) 
-            ? { ...team, tickets: serverTasks } 
-            : team
+          String(team.id) === String(activeTeamId) ? { ...team, tickets: serverTasks } : team
         );
       });
-      
-      console.log(`✅ ID ${activeTeamId} 팀 티켓 동기화 완료: ${serverTasks.length}개`);
     }
-  }, [ticketData, activeTeamId, localTeams.length]);
+  }, [ticketData, activeTeamId, localTeams]);
 
   // 현재 활성화된 팀 객체를 실시간으로 찾아 유지
   const activeTeam = useMemo(() => {
@@ -397,6 +386,7 @@ export const useTeams = (currentUser: CurrentUser | null) => {
             : team,
         ),
       );
+      return { ok: true, message: '인증 성공' };
     }
 
     setActiveTeamId(teamId);
@@ -458,6 +448,7 @@ export const useTeams = (currentUser: CurrentUser | null) => {
 
     const newTicket: Ticket = {
       id: Date.now(),
+      task_number: 0,
       title,
       content,
       requester: currentUser.name,

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -5,7 +5,7 @@
  */
 
 import { useState, useMemo, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Team, Ticket, CurrentUser, TeamFromApi } from '../types';
 import { INITIAL_TEAM, AVATARS } from '../utils/constants';
 import { getTeamsApi } from '../api/team';
@@ -218,10 +218,13 @@ export const useTeams = (currentUser: CurrentUser | null) => {
     return /^\d{6}$/.test(password);
   };
 
+  const queryClient = useQueryClient();
+
   const handleDeleteTicketApi = async (ticketId: number) => {
   try {
     const response = await deleteTicketApi(ticketId);
     if (response.success) {
+      await queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
       setTeams((prevTeams) =>
         prevTeams.map((team) => {
           if (String(team.id) === String(activeTeamId)) {

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -65,6 +65,9 @@ export const useTeams = (currentUser: CurrentUser | null) => {
   // 새로고침 시, 로컬스토리지에 저장된 팀 ID를 가져오기
   const [activeTeamId, setActiveTeamId] = useState<string | null>(null);
 
+  // 인증 대기 중인 팀 ID (비밀번호 입력 후 인증이 완료되면 activeTeamId로 이동)
+  const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
+
   const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
 
   const { data: detailData } = useQuery({
@@ -251,14 +254,17 @@ export const useTeams = (currentUser: CurrentUser | null) => {
     userName: string,
     action: string,
     type: 'default' | 'info' | 'success' | 'error' = 'default',
+    overrideTeamId?: string
   ) => {
-    if (!activeTeamId) return;
+    // activeTeamId가 없는데 overrideTeamId도 없다면 그때만 리턴
+    const targetTeamId = overrideTeamId || activeTeamId;
+    if (!targetTeamId) return;
 
     const time = formatLogTime();
 
     setTeams((prev) =>
       prev.map((t) =>
-        t.id === activeTeamId
+        t.id === targetTeamId
           ? {
               ...t,
               logs: [
@@ -369,9 +375,9 @@ export const useTeams = (currentUser: CurrentUser | null) => {
     );
 
     if (!isAlreadyMember) {
-      setTeams((prev) =>
-        prev.map((team) =>
-          team.id === teamId
+      setTeams(prev => 
+        prev.map(team => 
+        String(team.id) === String(teamId)
             ? {
                 ...team,
                 members: [...team.members, currentUser],
@@ -386,11 +392,9 @@ export const useTeams = (currentUser: CurrentUser | null) => {
             : team,
         ),
       );
-      return { ok: true, message: '인증 성공' };
     }
 
-    setActiveTeamId(teamId);
-
+    // 여기서 setActiveTeamId를 하지 않고, 성공 여부만 반환
     return {
       ok: true,
       message: '팀 입장 완료',
@@ -578,6 +582,8 @@ export const useTeams = (currentUser: CurrentUser | null) => {
     selectedTicketId,
     handleDeleteTicketApi,
     handleEditPosition,
+    pendingTeamId,
+    setPendingTeamId
   };
 };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -101,9 +101,6 @@ export const Dashboard = ({
       setActiveModal(null);
       form.reset();
 
-    // 💡 참고: 이제 여기서 수동으로 setTeams를 통해 tickets 배열에 
-    // 직접 push 할 필요가 없습니다. React Query가 데이터를 새로 가져오기 때문입니다.
-
     } catch (error) {
       console.error("티켓 생성 실패:", error);
       alert("업무 요청 중 오류가 발생했습니다.");

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { KanbanColumn } from '../components/task/KanbanBoard';
 import { createTicketApi, type CreateTicketRequest } from '../api/tickets';
 import { Modal } from '../components/ui/Modal';
 import { useEffect } from 'react';
+import { useQueryClient } from "@tanstack/react-query";
 
 interface DashboardProps {
   activeTeam: Team; 
@@ -28,6 +29,8 @@ export const Dashboard = ({
   activeModal,
   setActiveModal
 }: DashboardProps) => {
+
+  const queryClient = useQueryClient();
   
   const closeCreateModal = () => setActiveModal(null);
 
@@ -63,6 +66,7 @@ export const Dashboard = ({
       };
 
       const result = await createTicketApi(Number(activeTeamId), ticketData);
+      queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
       const rawTicket = result.data || result;
       const serverTeamId = String(rawTicket.team_id || activeTeamId);
 
@@ -96,6 +100,9 @@ export const Dashboard = ({
       addLog(finalTicket.id, currentUser.name, `새 업무 요청: ${finalTicket.title}`, 'success');
       setActiveModal(null);
       form.reset();
+
+    // 💡 참고: 이제 여기서 수동으로 setTeams를 통해 tickets 배열에 
+    // 직접 push 할 필요가 없습니다. React Query가 데이터를 새로 가져오기 때문입니다.
 
     } catch (error) {
       console.error("티켓 생성 실패:", error);

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -13,7 +13,6 @@ import type { Team, TeamFromApi, CurrentUser } from "../types";
 interface LobbyProps {
   currentUser: CurrentUser; // 현재 접속한 사용자 정보
   onLogout: () => void; // App.tsx에서 내려준 공통 로그아웃 함수
-  // setActiveTeamId: (id: string) => void; // 클릭한 팀을 활성화하는 함수
   setPendingTeamId: (id: string) => void; // 클릭한 팀 ID를 임시로 저장하는 함수 (인증을 시작할 팀)
   setIsTeamAuthorized: (auth: boolean) => void;
   setIsCreateTeamModalOpen: () => void; // 새 팀 만들기 모달 열기

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -13,7 +13,8 @@ import type { Team, TeamFromApi, CurrentUser } from "../types";
 interface LobbyProps {
   currentUser: CurrentUser; // 현재 접속한 사용자 정보
   onLogout: () => void; // App.tsx에서 내려준 공통 로그아웃 함수
-  setActiveTeamId: (id: string) => void; // 클릭한 팀을 활성화하는 함수
+  // setActiveTeamId: (id: string) => void; // 클릭한 팀을 활성화하는 함수
+  setPendingTeamId: (id: string) => void; // 클릭한 팀 ID를 임시로 저장하는 함수 (인증을 시작할 팀)
   setIsTeamAuthorized: (auth: boolean) => void;
   setIsCreateTeamModalOpen: () => void; // 새 팀 만들기 모달 열기
   setIsTeamAuthModalOpen: () => void; // 비밀번호 인증 모달 열기
@@ -50,7 +51,7 @@ const convertTeam = (team: TeamFromApi): Team => ({
 export const Lobby = ({
   currentUser,
   onLogout,
-  setActiveTeamId,
+  setPendingTeamId,
   setIsCreateTeamModalOpen,
   setIsTeamAuthModalOpen,
 }: LobbyProps) => {
@@ -136,7 +137,7 @@ export const Lobby = ({
   }) => (
     <div
       onClick={() => {
-        setActiveTeamId(team.id); // 클릭한 팀 ID 저장
+        setPendingTeamId(team.id); // 클릭한 팀 ID 저장
         setIsTeamAuthModalOpen(); // 인증 모달(비밀번호 입력) 호출
       }}
       className="relative w-full max-w-[320px] rounded-[28px] bg-white px-6 py-6 shadow-sm border border-slate-100 cursor-pointer transition-all hover:shadow-md"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface Comment {
 // 업무 티켓(Task) 정보
 export interface Ticket {
   id: number;
+  task_number: number;
   title: string;
   content: string;
   requester: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -117,8 +117,7 @@ export const INITIAL_TEAM: Team = {
     {
       id: 1, // DB의 PK와 매칭됨
       title: 'API 명세서 수정 요청',
-      content:
-        '로그인 시 반환되는 JWT 토큰에 유저 권한 정보 추가가 필요합니다.',
+      content: '로그인 시 반환되는 JWT 토큰에 유저 권한 정보 추가가 필요합니다.',
       requester: '영아',
       worker: '민수',
       status: 'Doing',
@@ -143,6 +142,7 @@ export const INITIAL_TEAM: Team = {
           time: '2026.03.11 10:15',
         },
       ],
+      task_number: 0
     },
     {
       id: 2,
@@ -153,6 +153,7 @@ export const INITIAL_TEAM: Team = {
       status: 'Todo',
       createdAt: '2026.03.11 11:30',
       comments: [],
+      task_number: 1
     },
   ],
   logs: [


### PR DESCRIPTION
## 작업 내용
[기존 수정 사항]
- [x] 팀 입장 직후 빈 화면 현상 
- [x] 로그인 화면 401 에러 
- [x] task 상세 조회 시, task 번호 수정
- [x] 테스크 생성/삭제 시, ui 즉각 반영되도록 수정 
- [x] 유저 정보 복원 한번만 실행하도록 수정

[멘토님 피드백]
- [x] task 목록 조회 api 호출 조건 추가

## 해결 방법
1. 팀 목록이 나중에 추가되어도 티켓 목록 조회가 다시 실행될 수 있도록 localTeams를 의존성 배열에 추가
2. ticketData useQuery가 유저 정보랑 activeTeamId가 있을 때만 실행하도록 수정
3. response id에서 task_number로 변경
4. React Query의 invalidateQueries 활용
5. React Query 사용하도록 변경
6. 팀 비번 입력 후 확인까지 진행해야 task 목록 조회 api 호출