### PR TITLE
[feat] 아카이브 > 회의록 목록 조회, 작성, 상세 조회, 수정, 삭제 api 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",
     "dayjs": "^1.11.19",
@@ -18,7 +19,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.2.1)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
@@ -35,6 +38,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -620,6 +626,11 @@ packages:
     resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
@@ -862,6 +873,11 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -937,6 +953,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -1295,12 +1315,36 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1325,6 +1369,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -1449,6 +1514,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1506,11 +1575,17 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1639,6 +1714,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2120,6 +2198,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.1)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.1
+
   '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@tailwindcss/node': 4.2.1
@@ -2400,6 +2483,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   dayjs@1.11.20: {}
@@ -2484,6 +2569,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -2821,7 +2908,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -2837,6 +2933,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2929,6 +3082,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -3106,6 +3317,11 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -3165,6 +3381,17 @@ snapshots:
 
   react@19.2.4: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3181,6 +3408,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@4.0.0: {}
 
@@ -3332,6 +3565,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ export default function App() {
     createNote,
     leaveTeam,
     editNote,
+    deleteNote,
   } = useTeams(currentUser, selectedTicketId);
 
   // --- UI 상태 관리 ---
@@ -93,6 +94,7 @@ export default function App() {
     activeTeam?.tickets.find((t) => t.id === selectedTicketId) ?? null;
 
   // 회의록 상태
+  const [isNotePending, setIsNotePending] = useState<boolean>(false);
   const [selectedNote, setSelectedNote] = useState<TeamArchiveData | null>(
     null,
   );
@@ -426,13 +428,23 @@ export default function App() {
   };
 
   // 회의록 기록
-  const handleCreateNote = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleCreateNote = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    createNote(noteData);
+    if (isNotePending) return;
+    setIsNotePending(true);
 
-    setActiveModal(null);
-    setNoteData({ title: '', content: '' });
+    try {
+      await createNote(noteData);
+
+      alert('회의록이 성공적으로 기록되었습니다.');
+      setActiveModal(null);
+      setNoteData({ title: '', content: '' });
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setIsNotePending(false);
+    }
   };
 
   const handleOpenUpdateNoteModal = (note: TeamArchiveData) => {
@@ -456,6 +468,23 @@ export default function App() {
       console.log(error);
     } finally {
       setIsEditNotePending(false);
+    }
+  };
+
+  // 회의록 삭제
+  const handleDeleteNote = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    const noteId = selectedNote?.id;
+    if (!noteId) return;
+
+    try {
+      await deleteNote(noteId);
+      alert('회의록이 성공적으로 삭제되었습니다.');
+      setSelectedNote(null);
+    } catch (error) {
+      console.log(error);
+      alert('회의록 삭제에 실패했습니다.');
     }
   };
 
@@ -1157,16 +1186,16 @@ export default function App() {
 
           <div className="flex justify-between">
             <button
+              onClick={(e) => handleDeleteNote(e)}
+              className="px-4 py-4 bg-red-100 hover:bg-red-200 text-red-500 rounded-2xl font-bold cursor-pointer"
+            >
+              회의록 삭제
+            </button>
+            <button
               onClick={() => handleOpenUpdateNoteModal(selectedNote)}
               className="px-4 py-4 bg-blue-600 hover:bg-blue-700 text-white rounded-2xl font-bold cursor-pointer"
             >
               회의록 수정
-            </button>
-            <button
-              onClick={() => setSelectedNote(null)}
-              className="px-4 py-4 bg-slate-900 hover:bg-slate-800 text-white rounded-2xl font-bold cursor-pointer"
-            >
-              확인 완료
             </button>
           </div>
         </Modal>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import {
   editMemberPositionApi,
 } from './api/member';
 import { createDocApi, createQuickLinkApi } from './api/archive';
-import { AxiosError } from 'axios';
+// import { AxiosError } from 'axios';
 
 // 레이아웃 및 페이지
 import { Sidebar } from './components/layout/Sidebar';
@@ -28,12 +28,7 @@ import { Modal } from './components/ui/Modal';
 
 // 훅 및 타입
 import { useTeams } from './hooks/useTeams';
-import {
-  type Member,
-  type CurrentUser,
-  type Note,
-  type TeamLink,
-} from './types';
+import { type Member, type CurrentUser, type TeamArchiveData } from './types';
 import { validateUrl } from './utils/validation';
 
 export default function App() {
@@ -97,7 +92,9 @@ export default function App() {
     activeTeam?.tickets.find((t) => t.id === selectedTicketId) ?? null;
 
   // 회의록 상태
-  const [selectedNote, setSelectedNote] = useState<Note | null>(null);
+  const [selectedNote, setSelectedNote] = useState<TeamArchiveData | null>(
+    null,
+  );
   const [note, setNote] = useState<{ title: string; content: string }>({
     title: '',
     content: '',
@@ -122,7 +119,7 @@ export default function App() {
   const isLinkValid =
     linkData.title.length > 0 && validateUrl(linkData.content);
   const [isLinkPending, setIsLinkPending] = useState<boolean>(false);
-  const [selectedLinkItem, setSelectedLinkItem] = useState<TeamLink>();
+  const [selectedLinkItem, setSelectedLinkItem] = useState<TeamArchiveData>();
   const [docData, setDocData] = useState<{ title: string; file: File | null }>({
     title: '',
     file: null,
@@ -180,31 +177,31 @@ export default function App() {
     mutationFn: ({ teamId, data }: { teamId: string; data: JoinTeamRequest }) =>
       joinTeamApi(teamId, data),
     onSuccess: (data) => {
-      if (data && (data.success || data.data)) { 
-      console.log("팀 입장 성공!");
+      if (data && (data.success || data.data)) {
+        console.log('팀 입장 성공!');
 
-      // 인증 성공 시 처리 로직
-      if (pendingTeamId) {
-        setActiveTeamId(pendingTeamId);
+        // 인증 성공 시 처리 로직
+        if (pendingTeamId) {
+          setActiveTeamId(pendingTeamId);
+        }
+
+        queryClient.invalidateQueries({ queryKey: ['teams'] });
+        setIsTeamAuthorized(true);
+        localStorage.setItem('isTeamAuthorized', 'true');
+        setActiveModal(null);
+        setAuthPassword(Array(6).fill(''));
+        setAuthError('');
+        setAuthCursorIndex(0);
+        setShowAuthPassword(false);
+        setIsAuthManualEditing(false); // 수정 모드 초기화
+        setPendingTeamId(null); // 인증 후에는 pendingTeamId 초기화
+      } else {
+        // 서버에서 200~299 사이 코드를 줬지만 내용은 에러인 경우
+        setAuthError(data?.error || '비밀번호가 일치하지 않습니다.');
       }
-
-      queryClient.invalidateQueries({ queryKey: ['teams'] });
-      setIsTeamAuthorized(true);
-      localStorage.setItem('isTeamAuthorized', 'true');
-      setActiveModal(null);
-      setAuthPassword(Array(6).fill(''));
-      setAuthError('');
-      setAuthCursorIndex(0);
-      setShowAuthPassword(false);
-      setIsAuthManualEditing(false); // 수정 모드 초기화
-      setPendingTeamId(null); // 인증 후에는 pendingTeamId 초기화
-    } else {
-      // 서버에서 200~299 사이 코드를 줬지만 내용은 에러인 경우
-      setAuthError(data?.error || '비밀번호가 일치하지 않습니다.');
-    }
-  },
-  onError: (error: AxiosError<{ error?: string }>) => {
-      console.error("입장 에러:", error);
+    },
+    onError: (error: AxiosError<{ error?: string }>) => {
+      console.error('입장 에러:', error);
       const serverErrorMessage = error.response?.data?.error;
       setAuthError(serverErrorMessage || '비밀번호가 일치하지 않습니다.');
     },
@@ -428,7 +425,7 @@ export default function App() {
   const handleCreateNote = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    
+
     const title = formData.get('title') as string;
     const content = formData.get('content') as string;
 
@@ -590,23 +587,22 @@ export default function App() {
       return;
     console.log('탈퇴 시작 - 팀 ID:', teamId);
     try {
-    // 훅에 있는 leaveTeam 실행 (내부적으로 API 호출 및 쿼리 무효화 처리)
-    await leaveTeam(); 
+      // 훅에 있는 leaveTeam 실행 (내부적으로 API 호출 및 쿼리 무효화 처리)
+      await leaveTeam();
 
-    // UI 상태 초기화
-    setIsTeamAuthorized(false);
-    setActiveTeamId(null);
-    setView('dashboard');
+      // UI 상태 초기화
+      setIsTeamAuthorized(false);
+      setActiveTeamId(null);
+      setView('dashboard');
 
-    setTimeout(() => {
-      alert('팀 탈퇴가 완료되었습니다.');
-    }, 100);
-
-  } catch (error: unknown) {
-    console.error('탈퇴 처리 중 오류:', error);
-    alert('팀 탈퇴 처리 중 문제가 발생했습니다.');
-  }
-};
+      setTimeout(() => {
+        alert('팀 탈퇴가 완료되었습니다.');
+      }, 100);
+    } catch (error: unknown) {
+      console.error('탈퇴 처리 중 오류:', error);
+      alert('팀 탈퇴 처리 중 문제가 발생했습니다.');
+    }
+  };
 
   // 포지션 수정
   const editPosition = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import {
   editMemberPositionApi,
 } from './api/member';
 import { createDocApi, createQuickLinkApi } from './api/archive';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
 // import { AxiosError } from 'axios';
 
 // 레이아웃 및 페이지
@@ -103,7 +106,9 @@ export default function App() {
     content: '',
   });
   const isFormValid =
-    noteData.title.trim().length > 0 && noteData.content.trim().length > 0;
+    noteData.title.trim().length > 0 &&
+    noteData.title.length <= 100 &&
+    noteData.content.trim().length > 0;
   const [isEditNotePending, setIsEditNotePending] = useState<boolean>(false);
 
   // 포지션 수정 관련 상태
@@ -477,6 +482,7 @@ export default function App() {
 
     const noteId = selectedNote?.id;
     if (!noteId) return;
+    if (!window.confirm('정말 이 회의록을 삭제하시겠습니까?')) return;
 
     try {
       await deleteNote(noteId);
@@ -947,16 +953,25 @@ export default function App() {
         }}
         title="회의록 기록"
       >
-        <form onSubmit={handleCreateNote} className="space-y-6">
+        <form onSubmit={handleCreateNote}>
           <input
             name="title"
             onChange={(e) =>
               setNoteData({ ...noteData, title: e.target.value })
             }
+            maxLength={100}
             required
-            className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none font-bold"
+            className="w-full px-6 py-4 mb-1 bg-slate-50 rounded-2xl outline-none font-bold"
             placeholder="회의 제목"
           />
+          <span
+            className={`flex justify-end mb-6 text-xs font-medium ${
+              noteData.title.length > 100 ? 'text-red-500' : 'text-slate-400'
+            }`}
+          >
+            {noteData.title.length} / 100
+          </span>
+
           <textarea
             name="content"
             onChange={(e) =>
@@ -964,7 +979,7 @@ export default function App() {
             }
             required
             rows={8}
-            className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none"
+            className="w-full px-6 py-4 mb-6 bg-slate-50 rounded-2xl outline-none"
             placeholder="내용 입력"
           />
           <button
@@ -1179,9 +1194,11 @@ export default function App() {
               {selectedNote.title}
             </p>
             <hr className="mb-4 text-slate-200" />
-            <p className="whitespace-pre-wrap text-slate-600 leading-relaxed text-sm">
-              {selectedNote.content}
-            </p>
+            <div className="prose prose-slate max-w-none prose-p:leading-relaxed prose-pre:bg-slate-900 ">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {selectedNote.content}
+              </ReactMarkdown>
+            </div>
           </div>
 
           <div className="flex justify-between">
@@ -1208,22 +1225,30 @@ export default function App() {
         }}
         title="회의록 수정"
       >
-        <form onSubmit={handlerEditNote} className="space-y-6">
+        <form onSubmit={handlerEditNote}>
           <input
             name="title"
             required
-            className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none font-bold"
+            className="w-full px-6 py-4 mb-1 bg-slate-50 rounded-2xl outline-none font-bold"
             placeholder="회의 제목"
             value={noteData.title}
             onChange={(e) =>
               setNoteData({ ...noteData, title: e.target.value })
             }
+            maxLength={100}
           />
+          <span
+            className={`flex justify-end mb-6 text-xs font-medium ${
+              noteData.title.length > 100 ? 'text-red-500' : 'text-slate-400'
+            }`}
+          >
+            {noteData.title.length} / 100
+          </span>
           <textarea
             name="content"
             required
             rows={8}
-            className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none"
+            className="w-full px-6 py-4 mb-6 bg-slate-50 rounded-2xl outline-none"
             placeholder="내용 입력"
             value={noteData.content}
             onChange={(e) =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ export default function App() {
     setActiveLogTab,
     createNote,
     leaveTeam,
+    editNote,
   } = useTeams(currentUser, selectedTicketId);
 
   // --- UI 상태 관리 ---
@@ -95,11 +96,13 @@ export default function App() {
   const [selectedNote, setSelectedNote] = useState<TeamArchiveData | null>(
     null,
   );
-  const [note, setNote] = useState<{ title: string; content: string }>({
+  const [noteData, setNoteData] = useState<{ title: string; content: string }>({
     title: '',
     content: '',
   });
-  const isNoteValid = note.title.length > 0 && note.content.length > 0;
+  const isFormValid =
+    noteData.title.trim().length > 0 && noteData.content.trim().length > 0;
+  const [isEditNotePending, setIsEditNotePending] = useState<boolean>(false);
 
   // 포지션 수정 관련 상태
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
@@ -422,24 +425,38 @@ export default function App() {
     });
   };
 
+  // 회의록 기록
   const handleCreateNote = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formData = new FormData(e.currentTarget);
 
-    const title = formData.get('title') as string;
-    const content = formData.get('content') as string;
-
-    // 훅에서 가져온 createNote 실행
-    createNote(title, content);
+    createNote(noteData);
 
     setActiveModal(null);
-    setNote({ title: '', content: '' });
+    setNoteData({ title: '', content: '' });
+  };
+
+  const handleOpenUpdateNoteModal = (note: TeamArchiveData) => {
+    setNoteData({ title: note.title, content: note.content });
+    setActiveModal('updateNote');
   };
 
   // 회의록 수정
-  const updateNote = (e: React.FormEvent<HTMLFormElement>) => {
+  const handlerEditNote = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(`${selectedNote?.id} 회의록을 수정합니다.`);
+
+    if (isEditNotePending || !selectedNote) return;
+    setIsEditNotePending(true);
+
+    try {
+      await editNote(selectedNote.id, noteData);
+      setSelectedNote({ ...selectedNote, ...noteData });
+      alert('회의록이 성공적으로 수정되었습니다.');
+      setActiveModal(null);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setIsEditNotePending(false);
+    }
   };
 
   // 새로운 링크 생성
@@ -897,21 +914,25 @@ export default function App() {
         isOpen={activeModal === 'note'}
         onClose={() => {
           setActiveModal(null);
-          setNote({ title: '', content: '' });
+          setNoteData({ title: '', content: '' });
         }}
         title="회의록 기록"
       >
         <form onSubmit={handleCreateNote} className="space-y-6">
           <input
             name="title"
-            onChange={(e) => setNote({ ...note, title: e.target.value })}
+            onChange={(e) =>
+              setNoteData({ ...noteData, title: e.target.value })
+            }
             required
             className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none font-bold"
             placeholder="회의 제목"
           />
           <textarea
             name="content"
-            onChange={(e) => setNote({ ...note, content: e.target.value })}
+            onChange={(e) =>
+              setNoteData({ ...noteData, content: e.target.value })
+            }
             required
             rows={8}
             className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none"
@@ -919,9 +940,9 @@ export default function App() {
           />
           <button
             type="submit"
-            disabled={!isNoteValid}
+            disabled={!isFormValid}
             className={`w-full py-4 rounded-2xl font-black shadow-lg ${
-              isNoteValid
+              isFormValid
                 ? 'bg-blue-600 hover:bg-blue-500 text-white cursor-pointer'
                 : 'bg-slate-700 text-slate-400 cursor-not-allowed'
             }`}
@@ -1121,17 +1142,22 @@ export default function App() {
         <Modal
           isOpen={!!selectedNote}
           onClose={() => setSelectedNote(null)}
-          title={selectedNote.title}
+          title="회의록 상세"
           maxWidth="max-w-2xl"
         >
           <div className="bg-slate-50 p-6 rounded-3xl mb-6">
+            <p className="whitespace-pre-wrap mb-4 text-slate-800 leading-relaxed text-lg">
+              {selectedNote.title}
+            </p>
+            <hr className="mb-4 text-slate-200" />
             <p className="whitespace-pre-wrap text-slate-600 leading-relaxed text-sm">
               {selectedNote.content}
             </p>
           </div>
+
           <div className="flex justify-between">
             <button
-              onClick={() => setActiveModal('updateNote')}
+              onClick={() => handleOpenUpdateNoteModal(selectedNote)}
               className="px-4 py-4 bg-blue-600 hover:bg-blue-700 text-white rounded-2xl font-bold cursor-pointer"
             >
               회의록 수정
@@ -1148,16 +1174,21 @@ export default function App() {
 
       <Modal
         isOpen={activeModal === 'updateNote'}
-        onClose={() => setActiveModal(null)}
+        onClose={() => {
+          setActiveModal(null);
+        }}
         title="회의록 수정"
       >
-        <form onSubmit={updateNote} className="space-y-6">
+        <form onSubmit={handlerEditNote} className="space-y-6">
           <input
             name="title"
             required
             className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none font-bold"
             placeholder="회의 제목"
-            defaultValue={selectedNote?.title}
+            value={noteData.title}
+            onChange={(e) =>
+              setNoteData({ ...noteData, title: e.target.value })
+            }
           />
           <textarea
             name="content"
@@ -1165,9 +1196,19 @@ export default function App() {
             rows={8}
             className="w-full px-6 py-4 bg-slate-50 rounded-2xl outline-none"
             placeholder="내용 입력"
-            defaultValue={selectedNote?.content}
+            value={noteData.content}
+            onChange={(e) =>
+              setNoteData({ ...noteData, content: e.target.value })
+            }
           />
-          <button className="w-full bg-blue-600 text-white py-4 rounded-2xl font-black shadow-lg">
+          <button
+            disabled={isEditNotePending || !isFormValid}
+            className={`w-full py-4 rounded-2xl font-black shadow-lg transition-colors ${
+              isEditNotePending || !isFormValid
+                ? 'bg-slate-700 text-slate-400 cursor-not-allowed'
+                : 'bg-blue-600 hover:bg-blue-500 text-white cursor-pointer'
+            }`}
+          >
             수정하기
           </button>
         </form>

--- a/src/api/archive.ts
+++ b/src/api/archive.ts
@@ -91,14 +91,15 @@ export const getNotesApi = async (teamId: number) => {
   return response.data;
 };
 
-export const createNoteApi = async (
-  teamId: number,
-  title: string,
-  content: string,
-) => {
+export interface NoteRequest {
+  title: string;
+  content: string;
+}
+
+export const createNoteApi = async (teamId: number, data: NoteRequest) => {
   const response = await api.post(`/teams/${teamId}/archives/meeting`, {
-    title,
-    content,
+    title: data.title,
+    content: data.content,
   });
   return response.data;
 };
@@ -108,14 +109,10 @@ export const getNoteDetailApi = async (archiveId: number) => {
   return response.data;
 };
 
-export const editNoteApi = async (
-  archiveId: number,
-  title: string,
-  content: string,
-) => {
+export const editNoteApi = async (archiveId: number, data: NoteRequest) => {
   const response = await api.patch(`/archives/${archiveId}/meeting`, {
-    title,
-    content,
+    title: data.title,
+    content: data.content,
   });
   return response.data;
 };

--- a/src/api/archive.ts
+++ b/src/api/archive.ts
@@ -4,7 +4,6 @@
 
 import { api } from './client';
 
-// 퀵 링크 API
 // 퀵 링크 생성 요청 데이터 타입 정의
 export interface CreateQuickLinkRequest {
   title: string;
@@ -83,5 +82,45 @@ export const getDocApi = async (teamId: number) => {
 
 export const deleteDocApi = async (docId: number) => {
   const response = await api.delete(`/archives/${docId}/documents`);
+  return response.data;
+};
+
+// 회의록 관련 api
+export const getNotesApi = async (teamId: number) => {
+  const response = await api.get(`/teams/${teamId}/archives/meeting`);
+  return response.data;
+};
+
+export const createNoteApi = async (
+  teamId: number,
+  title: string,
+  content: string,
+) => {
+  const response = await api.post(`/teams/${teamId}/archives/meeting`, {
+    title,
+    content,
+  });
+  return response.data;
+};
+
+export const getNoteDetailApi = async (archiveId: number) => {
+  const response = await api.get(`/archives/${archiveId}/meeting`);
+  return response.data;
+};
+
+export const editNoteApi = async (
+  archiveId: number,
+  title: string,
+  content: string,
+) => {
+  const response = await api.patch(`/archives/${archiveId}/meeting`, {
+    title,
+    content,
+  });
+  return response.data;
+};
+
+export const deleteNoteApi = async (archiveId: number) => {
+  const response = await api.delete(`/archives/${archiveId}/meeting`);
   return response.data;
 };

--- a/src/components/ui/LinkCard.tsx
+++ b/src/components/ui/LinkCard.tsx
@@ -1,7 +1,7 @@
-import { FileText, FileCode, Link as LinkIcon } from 'lucide-react';
-import type { TeamLink } from '../../types';
+import { FileText, Link as LinkIcon } from 'lucide-react';
+import type { TeamArchiveData } from '../../types';
 
-export const LinkCard = ({ link }: { link: TeamLink }) => (
+export const LinkCard = ({ link }: { link: TeamArchiveData }) => (
   <a
     href={link.content}
     target="_blank"
@@ -12,20 +12,10 @@ export const LinkCard = ({ link }: { link: TeamLink }) => (
       {/* 타입별 아이콘 및 배경색 (인라인 조건부 렌더링) */}
       <div
         className={`w-10 h-10 rounded-xl flex items-center justify-center text-white shrink-0 ${
-          link.type === 'planning'
-            ? 'bg-orange-400' // 기획: 주황색
-            : link.type === 'dev'
-              ? 'bg-blue-400' // 개발: 파란색
-              : 'bg-slate-400' // 기타: 회색
+          link.type === 'LINK' ? 'bg-orange-400' : 'bg-purple-400'
         }`}
       >
-        {link.type === 'planning' ? (
-          <FileText size={18} />
-        ) : link.type === 'dev' ? (
-          <FileCode size={18} />
-        ) : (
-          <LinkIcon size={18} />
-        )}
+        {link.type === 'LINK' ? <LinkIcon size={18} /> : <FileText size={18} />}
       </div>
       {/* 링크 정보 섹션 (텍스트 넘침 방지 처리) */}
       <div className="overflow-hidden">

--- a/src/components/ui/NoteCard.tsx
+++ b/src/components/ui/NoteCard.tsx
@@ -1,9 +1,9 @@
 import { Eye } from 'lucide-react';
-import type { Note } from '../../types';
+import type { TeamArchiveData } from '../../types';
 
 interface NoteCardProps {
-  note: Note;
-  onClick: (note: Note) => void; // 카드 클릭 시 전체 내용을 보여주기 위한 핸들러
+  note: TeamArchiveData;
+  onClick: (note: TeamArchiveData) => void; // 카드 클릭 시 전체 내용을 보여주기 위한 핸들러
 }
 
 export const NoteCard = ({ note, onClick }: NoteCardProps) => (
@@ -13,11 +13,18 @@ export const NoteCard = ({ note, onClick }: NoteCardProps) => (
   >
     {/* 상단: 아이콘 및 날짜 정보 */}
     <div className="flex justify-between items-start mb-3">
-      <span className="text-[10px] font-bold text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">{note.date}</span>
-      <Eye size={16} className="text-slate-300 group-hover:text-blue-500 transition-colors shrink-0" />
+      <span className="text-[10px] font-bold text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
+        {note.created_at}
+      </span>
+      <Eye
+        size={16}
+        className="text-slate-300 group-hover:text-blue-500 transition-colors shrink-0"
+      />
     </div>
     {/* 중단: 제목 및 본문 미리보기(2줄 제한) */}
-    <h4 className="font-bold text-base group-hover:text-blue-600 mb-2 truncate">{note.title}</h4>
+    <h4 className="font-bold text-base group-hover:text-blue-600 mb-2 truncate">
+      {note.title}
+    </h4>
     {/* 하단: 작성자 정보 */}
     <div className="text-xs text-slate-500 line-clamp-4 leading-relaxed overflow-hidden flex-1 min-h-0">
       {note.content.replace(/[#*]/g, '')}

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -32,11 +32,14 @@ import {
 } from '../api/tickets';
 
 import {
+  createNoteApi,
   deleteDocApi,
   deleteQuickLinkApi,
+  editNoteApi,
   getDocApi,
   getNotesApi,
   getQuickLinksApi,
+  type NoteRequest,
 } from '../api/archive';
 import { updateMyStatusApi } from '../api/status';
 import { pusher } from '../utils/pusher';
@@ -131,11 +134,6 @@ export const useTeams = (
   // 어떤 로그 탭을 보고 있는지 상태 추가
   const [activeLogTab, setActiveLogTab] = useState<'all' | 'mine'>('all');
 
-  // 회의록 api 연동 전 로컬에서 관리할 수 있도록 상태 선언
-  const [localNotes, setLocalNotes] = useState<
-    Record<string, TeamArchiveData[]>
-  >({});
-
   // GET /teams API 호출로 팀 목록 가져오기
   const { data: teamListData } = useQuery({
     queryKey: ['teams'],
@@ -184,24 +182,6 @@ export const useTeams = (
     queryFn: () => getNotesApi(Number(activeTeamId)),
     enabled: !!activeTeamId && !!currentUser,
   });
-
-  // 회의록 생성 함수 (API 연결 전 로컬에서만 실행되도록)
-  const createNote = (title: string, content: string) => {
-    if (!activeTeamId || !currentUser) return;
-
-    const newNote: TeamArchiveData = {
-      id: Date.now(),
-      type: 'NOTE',
-      title,
-      content,
-      created_at: new Date().toISOString(),
-    };
-
-    setLocalNotes((prev) => ({
-      ...prev,
-      [activeTeamId]: [newNote, ...(prev[activeTeamId] || [])],
-    }));
-  };
 
   const queryClient = useQueryClient();
 
@@ -698,6 +678,23 @@ export const useTeams = (
     });
   };
 
+  // 회의록 생성
+  const createNote = async (data: NoteRequest) => {
+    await createNoteApi(Number(activeTeamId), data);
+
+    await queryClient.invalidateQueries({
+      queryKey: ['noteData', activeTeamId],
+    });
+  };
+
+  // 회의록 수정
+  const editNote = async (noteId: number, data: NoteRequest) => {
+    await editNoteApi(noteId, data);
+
+    await queryClient.invalidateQueries({
+      queryKey: ['noteData', activeTeamId],
+    });
+  };
   // 외부 컴포넌트에서 사용할 데이터와 함수 반환
   return {
     currentUser,
@@ -729,5 +726,6 @@ export const useTeams = (
     handleCreateDoc,
     handleDeleteDoc,
     createNote,
+    editNote,
   };
 };

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -34,6 +34,7 @@ import {
 import {
   createNoteApi,
   deleteDocApi,
+  deleteNoteApi,
   deleteQuickLinkApi,
   editNoteApi,
   getDocApi,
@@ -695,6 +696,14 @@ export const useTeams = (
       queryKey: ['noteData', activeTeamId],
     });
   };
+
+  // 회의록 삭제
+  const deleteNote = async (noteId: number) => {
+    await deleteNoteApi(noteId);
+    await queryClient.invalidateQueries({
+      queryKey: ['noteData', activeTeamId],
+    });
+  };
   // 외부 컴포넌트에서 사용할 데이터와 함수 반환
   return {
     currentUser,
@@ -727,5 +736,6 @@ export const useTeams = (
     handleDeleteDoc,
     createNote,
     editNote,
+    deleteNote,
   };
 };

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -11,13 +11,12 @@ import type {
   Ticket,
   CurrentUser,
   TeamFromApi,
-  TeamLink,
+  TeamArchiveData,
   NewTaskNotification,
   PusherCommentData,
   TaskBaseFromApi,
   TaskComment,
   TaskCommentFromApi,
-  Note,
 } from '../types';
 import { INITIAL_TEAM, AVATARS } from '../utils/constants';
 import { getTeamsApi, joinTeamApi } from '../api/team';
@@ -36,12 +35,17 @@ import {
   deleteDocApi,
   deleteQuickLinkApi,
   getDocApi,
+  getNotesApi,
   getQuickLinksApi,
 } from '../api/archive';
 import { updateMyStatusApi } from '../api/status';
-import { pusher } from "../utils/pusher";
-import { getTeamLogsApi } from "../api/log";
-import { createCommentApi, DeleteCommentApi, updateCommentApi } from "../api/comments";
+import { pusher } from '../utils/pusher';
+import { getTeamLogsApi } from '../api/log';
+import {
+  createCommentApi,
+  DeleteCommentApi,
+  updateCommentApi,
+} from '../api/comments';
 
 // 상태별 색 매핑
 const STATUS_COLORS: Record<string, string> = {
@@ -52,15 +56,21 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 // 로그의 액션 타입에 따라 UI 색상을 결정하는 헬퍼 함수
-const getLogDisplayType = (actionType: string, message: string): 'default' | 'info' | 'success' | 'error' => {
-  if (actionType === 'CREATE_TASK' || actionType === 'ACCEPT_TASK') return 'info';
-  if (actionType === 'APPROVE_TASK' || actionType === 'STATUS_CHANGE') return 'success';
-  if (actionType === 'REJECT_TASK' || actionType === 'CANCEL_TASK') return 'error';
-  
+const getLogDisplayType = (
+  actionType: string,
+  message: string,
+): 'default' | 'info' | 'success' | 'error' => {
+  if (actionType === 'CREATE_TASK' || actionType === 'ACCEPT_TASK')
+    return 'info';
+  if (actionType === 'APPROVE_TASK' || actionType === 'STATUS_CHANGE')
+    return 'success';
+  if (actionType === 'REJECT_TASK' || actionType === 'CANCEL_TASK')
+    return 'error';
+
   // 타입이 명확하지 않을 때 메시지 내용으로 한 번 더 체크
   if (message.includes('반려') || message.includes('취소')) return 'error';
   if (message.includes('상태') || message.includes('승인')) return 'success';
-  
+
   return 'default';
 };
 
@@ -91,9 +101,9 @@ const convertTeam = (team: TeamFromApi): Team => ({
       const statusLabel = m.status || '업무 중'; // 기본값 설정
       return [
         m.user.name,
-        { 
+        {
           label: statusLabel,
-          color: STATUS_COLORS[statusLabel] || 'bg-green-500' 
+          color: STATUS_COLORS[statusLabel] || 'bg-green-500',
         },
       ];
     }),
@@ -112,7 +122,6 @@ export const useTeams = (
   currentUser: CurrentUser | null,
   selectedTicketId: number | null,
 ) => {
-
   // 새로고침 시, 로컬스토리지에 저장된 팀 ID를 가져오기
   const [activeTeamId, setActiveTeamId] = useState<string | null>(null);
 
@@ -123,7 +132,9 @@ export const useTeams = (
   const [activeLogTab, setActiveLogTab] = useState<'all' | 'mine'>('all');
 
   // 회의록 api 연동 전 로컬에서 관리할 수 있도록 상태 선언
-  const [localNotes, setLocalNotes] = useState<Record<string, Note[]>>({});
+  const [localNotes, setLocalNotes] = useState<
+    Record<string, TeamArchiveData[]>
+  >({});
 
   // GET /teams API 호출로 팀 목록 가져오기
   const { data: teamListData } = useQuery({
@@ -143,16 +154,14 @@ export const useTeams = (
     queryKey: ['ticketDetail', selectedTicketId],
     queryFn: () => getTicketDetailApi(selectedTicketId!),
     enabled: !!selectedTicketId,
-    staleTime: 0
+    staleTime: 0,
   });
 
   // 로그 데이터 조회 (React Query)
   const { data: logData } = useQuery({
-    queryKey: ['logs', activeTeamId, activeLogTab], 
-    queryFn: () => getTeamLogsApi(
-      Number(activeTeamId), 
-      activeLogTab === 'mine'
-    ),
+    queryKey: ['logs', activeTeamId, activeLogTab],
+    queryFn: () =>
+      getTeamLogsApi(Number(activeTeamId), activeLogTab === 'mine'),
     enabled: !!activeTeamId,
   });
 
@@ -169,16 +178,23 @@ export const useTeams = (
     enabled: !!activeTeamId && !!currentUser,
   });
 
+  // 활성화된 팀의 회의록 목록 조회
+  const { data: noteData } = useQuery({
+    queryKey: ['noteData', activeTeamId],
+    queryFn: () => getNotesApi(Number(activeTeamId)),
+    enabled: !!activeTeamId && !!currentUser,
+  });
+
   // 회의록 생성 함수 (API 연결 전 로컬에서만 실행되도록)
   const createNote = (title: string, content: string) => {
     if (!activeTeamId || !currentUser) return;
 
-    const newNote: Note = {
+    const newNote: TeamArchiveData = {
       id: Date.now(),
+      type: 'NOTE',
       title,
       content,
-      author: currentUser.name,
-      date: new Date().toISOString().split('T')[0],
+      created_at: new Date().toISOString(),
     };
 
     setLocalNotes((prev) => ({
@@ -212,56 +228,63 @@ export const useTeams = (
     userChannel.bind('new-task-requested', (data: NewTaskNotification) => {
       alert(data.message);
       queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
-  });
+    });
 
     // pusher 리스너 - 테스크 상태 업데이트
-    teamChannel.bind('task-status-updated', (data: { taskId: number; status: string }) => {
-    console.log("📍 [실시간] 테스크 상태 변경 감지!", data);
-      queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
-    });
+    teamChannel.bind(
+      'task-status-updated',
+      (data: { taskId: number; status: string }) => {
+        console.log('📍 [실시간] 테스크 상태 변경 감지!', data);
+        queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
+      },
+    );
 
     // pusher 리스너 - 개인별 테스크 할당 알림
     userChannel.bind('new-task-requested', (data: NewTaskNotification) => {
-    console.log("🔔 나에게 온 새 업무 신호 수신:", data);
-    
-    // 나에게 할당된 요청 알림 - 추후에 토스트 알림으로 변경할 예정
-    alert(data.message);
+      console.log('🔔 나에게 온 새 업무 신호 수신:', data);
 
-    queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
-    queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] });
-  });
+      // 나에게 할당된 요청 알림 - 추후에 토스트 알림으로 변경할 예정
+      alert(data.message);
 
-  return () => {
+      queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
+      queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] });
+    });
+
+    return () => {
       pusher.unsubscribe(`team-${activeTeamId}`);
       pusher.unsubscribe(`user-${currentUser.uuid}`);
     };
   }, [activeTeamId, currentUser, queryClient]);
 
-useEffect(() => {
-  // 특정 테스크 모달이 열려 있을 때만 리스너를 가동합니다.
-  if (!selectedTicketId) return;
+  useEffect(() => {
+    // 특정 테스크 모달이 열려 있을 때만 리스너를 가동합니다.
+    if (!selectedTicketId) return;
 
-  console.log(`[Pusher] #${selectedTicketId} 테스크 채널 구독 시도...`);
-  const taskChannel = pusher.subscribe(`task-${selectedTicketId}`);
+    console.log(`[Pusher] #${selectedTicketId} 테스크 채널 구독 시도...`);
+    const taskChannel = pusher.subscribe(`task-${selectedTicketId}`);
 
-  taskChannel.bind('new-comment', (data: PusherCommentData) => {
-    console.log("💬 [Pusher] 실시간 댓글 이벤트 발생!", data);
-    // 💡 여기서 invalidateQueries를 호출해야 위 useMemo가 다시 작동합니다.
-    queryClient.invalidateQueries({ queryKey: ['ticketDetail', selectedTicketId] });
-  });
+    taskChannel.bind('new-comment', (data: PusherCommentData) => {
+      console.log('💬 [Pusher] 실시간 댓글 이벤트 발생!', data);
+      // 💡 여기서 invalidateQueries를 호출해야 위 useMemo가 다시 작동합니다.
+      queryClient.invalidateQueries({
+        queryKey: ['ticketDetail', selectedTicketId],
+      });
+    });
 
-  return () => {
-    pusher.unsubscribe(`task-${selectedTicketId}`);
-    taskChannel.unbind_all();
-  };
-}, [selectedTicketId, queryClient]);
+    return () => {
+      pusher.unsubscribe(`task-${selectedTicketId}`);
+      taskChannel.unbind_all();
+    };
+  }, [selectedTicketId, queryClient]);
 
   // 댓글 수정 핸들러
   const onUpdateComment = async (commentId: number, text: string) => {
     /* 수정 로직 */
     const response = await updateCommentApi(commentId, text);
     if (response.success) {
-      queryClient.invalidateQueries({ queryKey: ['ticketDetail', selectedTicketId] });
+      queryClient.invalidateQueries({
+        queryKey: ['ticketDetail', selectedTicketId],
+      });
     }
   };
 
@@ -269,97 +292,132 @@ useEffect(() => {
     /* 삭제 로직 */
     const response = await DeleteCommentApi(commentId);
     if (response.success) {
-      queryClient.invalidateQueries({ queryKey: ['ticketDetail', selectedTicketId] });
+      queryClient.invalidateQueries({
+        queryKey: ['ticketDetail', selectedTicketId],
+      });
     }
   };
 
   // teams 변수를 서버 데이터로부터 생성
   const teams = useMemo(() => {
-    return teamListData?.data ? teamListData.data.map(convertTeam) : [INITIAL_TEAM];
+    return teamListData?.data
+      ? teamListData.data.map(convertTeam)
+      : [INITIAL_TEAM];
   }, [teamListData]);
 
   // 현재 활성화된 팀 객체를 실시간으로 찾아 유지
   const activeTeam = useMemo(() => {
     if (!teamListData?.data || !activeTeamId) return null;
-    const rawTeam = teamListData.data.find((t: TeamFromApi) => String(t.id) === String(activeTeamId));
+    const rawTeam = teamListData.data.find(
+      (t: TeamFromApi) => String(t.id) === String(activeTeamId),
+    );
     if (!rawTeam) return null;
 
     // 기본 구조 변환 (Team 객체 초기화)
     const baseTeam = convertTeam(rawTeam);
 
     if (ticketData?.success && ticketData.data.tasks) {
-      baseTeam.tickets = ticketData.data.tasks.map((task: TaskBaseFromApi): Ticket => {
-        const isSelected = selectedTicketId !== null && Number(task.id) === Number(selectedTicketId);
+      baseTeam.tickets = ticketData.data.tasks.map(
+        (task: TaskBaseFromApi): Ticket => {
+          const isSelected =
+            selectedTicketId !== null &&
+            Number(task.id) === Number(selectedTicketId);
 
-        // 상세 데이터 타입 캐스팅
-        const detailMatch = detailData?.success && String(detailData.data.id) === String(task.id);
-        const currentDetail = detailMatch ? detailData.data : null;
+          // 상세 데이터 타입 캐스팅
+          const detailMatch =
+            detailData?.success &&
+            String(detailData.data.id) === String(task.id);
+          const currentDetail = detailMatch ? detailData.data : null;
 
-        let serverComments: TaskComment[] = [];
-        
-        if (isSelected && currentDetail && 'comments' in currentDetail) {
-          serverComments = currentDetail.comments.map((c: TaskCommentFromApi): TaskComment => ({
-            id: c.id,
-            user: c.user.name,
-            text: c.content,
-            time: new Date(c.created_at).toLocaleTimeString('ko-KR', { hour12: false }),
-          }));
-        }
+          let serverComments: TaskComment[] = [];
 
-        return {
-          id: task.id,
-          task_number: task.task_number,
-          title: task.title,
-          content: task.content,
-          status: task.status || 'Todo',
-          requester: task.requester_name,
-          worker: task.worker_name,
-          worker_id: String(task.worker_id),
-          createdAt: task.created_at?.split('T')[0] || '',
-          comments: serverComments,
-        };
-      });
+          if (isSelected && currentDetail && 'comments' in currentDetail) {
+            serverComments = currentDetail.comments.map(
+              (c: TaskCommentFromApi): TaskComment => ({
+                id: c.id,
+                user: c.user.name,
+                text: c.content,
+                time: new Date(c.created_at).toLocaleTimeString('ko-KR', {
+                  hour12: false,
+                }),
+              }),
+            );
+          }
+
+          return {
+            id: task.id,
+            task_number: task.task_number,
+            title: task.title,
+            content: task.content,
+            status: task.status || 'Todo',
+            requester: task.requester_name,
+            worker: task.worker_name,
+            worker_id: String(task.worker_id),
+            createdAt: task.created_at?.split('T')[0] || '',
+            comments: serverComments,
+          };
+        },
+      );
     }
 
     // 로그 조립
     if (logData?.success && Array.isArray(logData.data)) {
-      baseTeam.logs = logData.data.map((log: { id: number; task_id: number; user: { name: string }; message: string; created_at: string; action_type: string }) => ({
-        id: log.id,
-        ticketId: log.task_id,
-        user: log.user.name,
-        action: log.message,
-        time: new Date(log.created_at).toLocaleTimeString('ko-KR', { hour12: false }),
-        type: getLogDisplayType(log.action_type, log.message),
-      }));
+      baseTeam.logs = logData.data.map(
+        (log: {
+          id: number;
+          task_id: number;
+          user: { name: string };
+          message: string;
+          created_at: string;
+          action_type: string;
+        }) => ({
+          id: log.id,
+          ticketId: log.task_id,
+          user: log.user.name,
+          action: log.message,
+          time: new Date(log.created_at).toLocaleTimeString('ko-KR', {
+            hour12: false,
+          }),
+          type: getLogDisplayType(log.action_type, log.message),
+        }),
+      );
     }
 
     // 아카이브(링크/문서) 데이터 조립 추가
     const rawLinks = linkData?.data || [];
     const rawDocs = docData?.data || [];
-    baseTeam.links = [...rawLinks, ...rawDocs].sort((a, b) => 
-      (b.created_at || '').localeCompare(a.created_at || '')
-    ).map((link: TeamLink) => ({
-      id: link.id,
-      type: link.type,
-      title: link.title,
-      content: link.content,
-      createdAt: link.createdAt,
-    }));
+    baseTeam.links = [...rawLinks, ...rawDocs]
+      .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
+      .map((link: TeamArchiveData) => ({
+        id: link.id,
+        type: link.type,
+        title: link.title,
+        content: link.content,
+        created_at: link.created_at,
+      }));
 
-    // 아카이브 회의록 로컬 처리
-    baseTeam.notes = localNotes[activeTeamId] || [];
+    // 아카이브 회의록 데이터 조립
+
+    baseTeam.notes =
+      noteData?.data.map((note: TeamArchiveData) => ({
+        id: note.id,
+        type: note.type,
+        title: note.title,
+        content: note.content,
+        created_at: note.created_at,
+      })) || [];
 
     return baseTeam;
   }, [
-    activeTeamId, 
-    teamListData, 
-    ticketData, 
-    logData, 
+    activeTeamId,
+    teamListData,
+    ticketData,
+    logData,
     detailData,
     selectedTicketId,
     linkData,
     docData,
-    localNotes
+    noteData,
   ]);
 
   // 현재 유저가 참여 중인 팀 목록
@@ -406,23 +464,22 @@ useEffect(() => {
   };
 
   const joinTeam = async (teamId: string, password: string) => {
-  if (!currentUser) return { ok: false, message: '유저 정보가 없습니다.' };
+    if (!currentUser) return { ok: false, message: '유저 정보가 없습니다.' };
 
-  try {
-    // 받아온 teamId와 password를 API 함수에 전달하여 사용
-    const response = await joinTeamApi(String(teamId), { 
-      password,
-      userId: Number(currentUser.id) // 현재 유저의 ID 전달
-    });
+    try {
+      // 받아온 teamId와 password를 API 함수에 전달하여 사용
+      const response = await joinTeamApi(String(teamId), {
+        password,
+        userId: Number(currentUser.id), // 현재 유저의 ID 전달
+      });
 
       if (response.success) {
         // 가입 성공 시 서버의 팀 목록을 새로고침
         await queryClient.invalidateQueries({ queryKey: ['teams'] });
         return { ok: true, message: '팀 가입이 완료되었습니다.' };
       }
-      
-      return { ok: false, message: response.error || '가입에 실패했습니다.' };
 
+      return { ok: false, message: response.error || '가입에 실패했습니다.' };
     } catch (error: unknown) {
       console.error('팀 가입 중 오류:', error);
       return { ok: false, message: '서버 통신 중 오류가 발생했습니다.' };
@@ -444,8 +501,12 @@ useEffect(() => {
     try {
       const response = await apiMap[actionType](taskId);
       if (response.data?.success) {
-        await queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
-        await queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] });
+        await queryClient.invalidateQueries({
+          queryKey: ['tickets', activeTeamId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ['logs', activeTeamId],
+        });
         return { ok: true };
       }
     } catch (error: unknown) {
@@ -457,19 +518,21 @@ useEffect(() => {
   const handleDeleteTicketApi = async (ticketId: number) => {
     console.log(`[삭제 시도] 티켓:${ticketId}, 활성팀:${activeTeamId}`);
 
-  try {
-    const response = await deleteTicketApi(ticketId);
+    try {
+      const response = await deleteTicketApi(ticketId);
 
-    if (response.success) {
-      await queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
-      
-      return { ok: true };
+      if (response.success) {
+        await queryClient.invalidateQueries({
+          queryKey: ['tickets', activeTeamId],
+        });
+
+        return { ok: true };
+      }
+      return { ok: false, message: response.error || '삭제 권한이 없습니다.' };
+    } catch {
+      return { ok: false, message: '서버에서 권한을 거부했습니다.' };
     }
-    return { ok: false, message: response.error || "삭제 권한이 없습니다." };
-  } catch {
-    return { ok: false, message: "서버에서 권한을 거부했습니다." };
-  }
-};
+  };
 
   /**
    * [기능] createTeam: 새 팀 생성
@@ -501,14 +564,15 @@ useEffect(() => {
       return { ok: false, message: '이미 존재하는 팀 이름입니다.' };
     }
 
-    console.log("팀 생성 시도:", { teamName, teamPassword });
-    
+    console.log('팀 생성 시도:', { teamName, teamPassword });
+
     // 성공했다고 가정하고 서버 데이터 새로고침
     await queryClient.invalidateQueries({ queryKey: ['teams'] });
 
     return {
       ok: true,
-      message: '팀이 생성되었습니다. (서버 연동 시 자동으로 목록에 나타납니다.)',
+      message:
+        '팀이 생성되었습니다. (서버 연동 시 자동으로 목록에 나타납니다.)',
     };
   };
 
@@ -534,8 +598,12 @@ useEffect(() => {
       });
 
       if (response.success) {
-        await queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] });
-        await queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] });
+        await queryClient.invalidateQueries({
+          queryKey: ['tickets', activeTeamId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ['logs', activeTeamId],
+        });
         console.log('✅ 티켓 생성 성공 및 데이터 동기화 완료');
       }
     } catch (error: unknown) {
@@ -550,28 +618,34 @@ useEffect(() => {
   const handleAddComment = async (ticketId: number, text: string) => {
     if (!text || !currentUser || !activeTeamId) return false;
 
-  console.log(`🚀 [댓글전송] ${ticketId}번 테스크에 댓글 작성 시도: "${text}"`);
+    console.log(
+      `🚀 [댓글전송] ${ticketId}번 테스크에 댓글 작성 시도: "${text}"`,
+    );
 
-  try {
-    const response = await createCommentApi(ticketId, text); 
+    try {
+      const response = await createCommentApi(ticketId, text);
 
-    if (response.success) {
-      console.log("✅ [서버응답] 댓글 저장 완료. 데이터를 새로고침합니다.");
-      
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['ticketDetail', ticketId] }),
-        queryClient.invalidateQueries({ queryKey: ['tickets', activeTeamId] }),
-        queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] })
-      ]);
-      
-      return true;
+      if (response.success) {
+        console.log('✅ [서버응답] 댓글 저장 완료. 데이터를 새로고침합니다.');
+
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: ['ticketDetail', ticketId],
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ['tickets', activeTeamId],
+          }),
+          queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] }),
+        ]);
+
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('❌ [에러] 댓글 작성 실패:', error);
+      return false;
     }
-    return false;
-  } catch (error) {
-    console.error("❌ [에러] 댓글 작성 실패:", error);
-    return false;
-  }
-};
+  };
 
   /**
    * [기능] leaveTeam: 현재 유저를 팀 멤버 목록에서 제거
@@ -584,10 +658,10 @@ useEffect(() => {
   // 내 포지션 수정
   const handleEditPosition = async (newPosition: string) => {
     if (!activeTeamId || !currentUser) return;
-    
+
     try {
       console.log(`포지션 변경 시도: ${newPosition}`);
-      await queryClient.invalidateQueries({ queryKey: ['teams'] });      
+      await queryClient.invalidateQueries({ queryKey: ['teams'] });
     } catch (error: unknown) {
       console.error('포지션 수정 실패:', error);
     }
@@ -596,24 +670,32 @@ useEffect(() => {
   // 아카이브 > 퀵 링크 생성
   const handleCreateQuickLink = async () => {
     // 💡 setTeams 삭제 -> API 호출 후 invalidateQueries(['linkData']) 사용
-    await queryClient.invalidateQueries({ queryKey: ['linkData', activeTeamId] });
+    await queryClient.invalidateQueries({
+      queryKey: ['linkData', activeTeamId],
+    });
   };
 
   // 아카이브 > 퀵 링크 삭제
   const handleDeleteQuickLink = async (linkId: number) => {
     await deleteQuickLinkApi(linkId);
-    await queryClient.invalidateQueries({ queryKey: ['linkData', activeTeamId] });
+    await queryClient.invalidateQueries({
+      queryKey: ['linkData', activeTeamId],
+    });
   };
 
   // 아카이브 > 문서 생성
   const handleCreateDoc = async () => {
-    await queryClient.invalidateQueries({ queryKey: ['docData', activeTeamId] });
+    await queryClient.invalidateQueries({
+      queryKey: ['docData', activeTeamId],
+    });
   };
 
   // 아카이브 > 문서 삭제 (링크 삭제와 동일하게 처리)
   const handleDeleteDoc = async (docId: number) => {
     await deleteDocApi(docId);
-    await queryClient.invalidateQueries({ queryKey: ['docData', activeTeamId] });
+    await queryClient.invalidateQueries({
+      queryKey: ['docData', activeTeamId],
+    });
   };
 
   // 외부 컴포넌트에서 사용할 데이터와 함수 반환
@@ -646,6 +728,6 @@ useEffect(() => {
     handleDeleteQuickLink,
     handleCreateDoc,
     handleDeleteDoc,
-    createNote
+    createNote,
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,2 @@
-@import "tailwindcss";
+@import 'tailwindcss';
+@plugin "@tailwindcss/typography";

--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -28,7 +28,6 @@ export const Archive = ({
   setSelectedNote,
   setSelectedLinkItem,
 }: ArchiveProps) => {
-  console.log(activeTeam);
   return (
     <div className="flex flex-col gap-8 max-w-7xl mx-auto py-4">
       {/* 핵심 문서 & 퀵 링크 섹션 */}

--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -6,8 +6,8 @@ import {
   Eye,
   Trash2,
 } from 'lucide-react';
-import type { Team, Note, TeamLink } from '../types';
-import { getHostname } from '../utils/format';
+import type { Team, TeamArchiveData } from '../types';
+import { formatDate, getHostname } from '../utils/format';
 
 interface ArchiveProps {
   activeTeam: Team; // 현재 활성화된 팀의 모든 데이터 (links, notes 포함)
@@ -15,8 +15,8 @@ interface ArchiveProps {
   setIsDocModalOpen: (open: boolean) => void; // 문서 추가 모달 제어 함수
   setIsNoteModalOpen: (open: boolean) => void; // 회의록 추가 모달 제어 함수
   setIsDeleteLinkModalOpen: (open: boolean) => void; // 링크 삭제 모달 호출 함수
-  setSelectedNote: (note: Note) => void; // 특정 회의록 클릭 시 상세보기 모달 호출 함수
-  setSelectedLinkItem: (link: TeamLink) => void; // 특정 링크 클릭 시 삭제 모달 호출 함수
+  setSelectedNote: (note: TeamArchiveData) => void; // 특정 회의록 클릭 시 상세보기 모달 호출 함수
+  setSelectedLinkItem: (link: TeamArchiveData) => void; // 특정 링크 클릭 시 삭제 모달 호출 함수
 }
 
 export const Archive = ({
@@ -28,6 +28,7 @@ export const Archive = ({
   setSelectedNote,
   setSelectedLinkItem,
 }: ArchiveProps) => {
+  console.log(activeTeam);
   return (
     <div className="flex flex-col gap-8 max-w-7xl mx-auto py-4">
       {/* 핵심 문서 & 퀵 링크 섹션 */}
@@ -82,9 +83,7 @@ export const Archive = ({
                         <LinkIcon size={18} />
                       ) : link.type === 'PDF' ? (
                         <File size={18} />
-                      ) : (
-                        <LinkIcon size={18} />
-                      )}
+                      ) : null}
                     </div>
                     <div className="overflow-hidden">
                       <span
@@ -152,7 +151,7 @@ export const Archive = ({
               >
                 <div className="flex justify-between items-start mb-3">
                   <span className="text-[10px] font-bold text-blue-500 bg-blue-50 px-2 py-0.5 rounded-full">
-                    {note.date}
+                    {formatDate(note.created_at)}
                   </span>
                   <Eye
                     size={16}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,7 +40,7 @@ export interface Ticket {
   comments: TaskComment[];
 }
 
-// 공통 테스크 데이터 
+// 공통 테스크 데이터
 export interface TaskBaseFromApi {
   id: number;
   task_number: number;
@@ -113,31 +113,15 @@ export interface PusherCommentData {
   };
 }
 
-// 팀 아카이브: 회의록 데이터
-export interface Note {
-  id: number;
-  title: string;
-  content: string;
-  author: string;
-  date: string;
-}
+type ArchiveType = 'NOTE' | 'LINK' | 'PDF';
 
-// 팀 아카이브: 공유 링크 데이터
-export interface TeamLink {
+// 팀 아카이브: 공유 링크, 문서, 회의록 공통 데이터
+export interface TeamArchiveData {
   id: number;
-  type: string;
+  type: ArchiveType;
   title: string;
   content: string;
-  createdAt: string;
-}
-
-// 팀 아카이브: 문서 데이터
-export interface TeamDocument {
-  id: number;
-  type: string;
-  title: string;
-  content: string;
-  createdAt: string;
+  created_at: string;
 }
 
 /**
@@ -152,8 +136,8 @@ export interface Team {
   members: Member[];
   tickets: Ticket[];
   logs: Log[];
-  notes: Note[];
-  links: TeamLink[];
+  notes: TeamArchiveData[];
+  links: TeamArchiveData[];
   userStatuses: Record<string, UserStatus>;
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -117,7 +117,8 @@ export const INITIAL_TEAM: Team = {
     {
       id: 1, // DB의 PK와 매칭됨
       title: 'API 명세서 수정 요청',
-      content: '로그인 시 반환되는 JWT 토큰에 유저 권한 정보 추가가 필요합니다.',
+      content:
+        '로그인 시 반환되는 JWT 토큰에 유저 권한 정보 추가가 필요합니다.',
       requester: '영아',
       worker: '민수',
       status: 'Doing',
@@ -143,7 +144,7 @@ export const INITIAL_TEAM: Team = {
         },
       ],
       task_number: 0,
-      worker_id: ""
+      worker_id: '',
     },
     {
       id: 2,
@@ -155,7 +156,7 @@ export const INITIAL_TEAM: Team = {
       createdAt: '2026.03.11 11:30',
       comments: [],
       task_number: 1,
-      worker_id: ""
+      worker_id: '',
     },
   ],
   logs: [
@@ -173,8 +174,8 @@ export const INITIAL_TEAM: Team = {
       id: 1,
       title: '주간 회의록 (03.11)',
       content: '### 결정 사항\n- MVP 기능 확정\n- 이번주 UI 완성',
-      author: '영아',
-      date: '2026.03.11',
+      type: 'NOTE',
+      created_at: '2026.03.11',
     },
   ],
   links: [
@@ -183,15 +184,15 @@ export const INITIAL_TEAM: Team = {
       title: 'API 명세 링크',
       content:
         'https://www.notion.so/i-Station-API-ver2-3263c7fd06d980709274d7582b66cf0b?source=copy_link',
-      type: 'links',
-      createdAt: '2026.03.11',
+      type: 'LINK',
+      created_at: '2026.03.11',
     },
     {
       id: 2,
       title: '기획서 (Notion)입니다 반드시 확인해주세요',
       content: 'https://notion.so',
-      type: 'documents',
-      createdAt: '2026.03.11',
+      type: 'PDF',
+      created_at: '2026.03.11',
     },
   ],
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -25,3 +25,12 @@ export const getHostname = (url: string) => {
     return url;
   }
 };
+
+// 날짜 문자열을 'YYYY-MM-DD' 형식으로 변환하는 함수
+export const formatDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
## 작업내용
- 회의록 목록 조회, 작성, 수정, 삭제 api 연동
- 회의록 작성, 수정 모달 > 제목 100자 제한 예외처리
- 회의록 마크다운 렌더링 구현
- 링크, 문서, 회의록 데이터 통합

## 개발 제외
- 회의록 상세 조회 : 상세 내용 데이터는 프론트에서 핸들링 가능하여 제외함