### PR TITLE
[jh_feat/#69] 헤더 및 사이드바 기능 추가 + 상태 변경 기능 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ export default function App() {
     activeTeamId,
     setActiveTeamId,
     activeTeam,
+    onlineUsers,
     pendingTeamId,
     updateMyStatus,
     setPendingTeamId,
@@ -770,6 +771,7 @@ export default function App() {
             <Header
               view={view}
               activeTeam={activeTeam!}
+              onlineUsers={onlineUsers || []}
               setIsCreateModalOpen={() => setActiveModal('create')}
             />
             <div className="flex-1 overflow-y-auto p-6 bg-slate-50">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,6 @@ import { createDocApi, createQuickLinkApi } from './api/archive';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-// import { AxiosError } from 'axios';
-
 // 레이아웃 및 페이지
 import { Sidebar } from './components/layout/Sidebar';
 import { Header } from './components/layout/Header';
@@ -638,16 +636,9 @@ export default function App() {
   };
 
   const handleLeaveTeam = async (teamId: string | number | null) => {
-    if (!teamId) return;
-    if (
-      !window.confirm(
-        '정말 이 팀에서 탈퇴하시겠습니까? 다시 입장하려면 비밀번호가 필요합니다.',
-      )
-    )
-      return;
-    console.log('탈퇴 시작 - 팀 ID:', teamId);
-    try {
-      await leaveTeam();
+  if (!teamId) return;
+  try {
+    await leaveTeam(Number(teamId));
 
       setIsTeamAuthorized(false);
       setActiveTeamId(null);

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -2,6 +2,7 @@
  팀원 정보 관련 API 모음
  */
 
+import type { GetOnlineUsersResponse } from "../types";
 import { api } from './client';
 
 // 요청 데이터 타입 정의
@@ -31,4 +32,10 @@ export const editMemberPositionApi = async (
     data,
   );
   return response.data;
+};
+
+// 활동 중인 맴버 목록 조회 api
+export const getOnlineUsersApi = async (teamId: number): Promise<GetOnlineUsersResponse> => {
+  const res = await api.get(`/teams/${teamId}/members/active`);
+  return res.data;
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,23 +1,27 @@
 import { Plus } from 'lucide-react';
-import type { Team, Member } from '../../types';
+import type { Team } from '../../types';
 import { StatusBadge } from '../status/StatusBadge';
 
+interface OnlineUser {
+  id: number;
+  name: string;
+  avatar: string;
+  status: string;
+  statusColor: string;
+}
+
 interface HeaderProps {
-  view: 'dashboard' | 'members' | 'archive'; // 현재 활성화된 화면 뷰
-  activeTeam: Team; // 현재 사용자가 속한 팀 데이터
-  setIsCreateModalOpen: (open: boolean) => void; // 새 업무 요청 모달 열기 함수
+  view: 'dashboard' | 'members' | 'archive';
+  activeTeam: Team;
+  onlineUsers: OnlineUser[];
+  setIsCreateModalOpen: (open: boolean) => void;
 }
 
 export const Header = ({
   view,
-  activeTeam,
+  onlineUsers,
   setIsCreateModalOpen,
 }: HeaderProps) => {
-  // '자리 비움'이 아닌 팀원들만 필터링하여 상단에 노출
-  const onlineUsers = activeTeam.members.filter((m: Member) => {
-    const status = activeTeam.userStatuses[m.name];
-    return status && status.label !== '자리 비움';
-  });
 
   return (
     <header className="h-16 bg-white border-b border-slate-200 flex items-center justify-between px-8 shrink-0">
@@ -31,38 +35,38 @@ export const Header = ({
       <div className="flex items-center gap-4">
         {/* 오른쪽: 온라인 유저 아바타 스택 */}
         <div className="flex -space-x-2 mr-2">
-          {onlineUsers.map((member) => {
-            // 해당 멤버의 실제 상태 데이터 가져오기
-            const userStatus = activeTeam.userStatuses[member.name];
-
+          {onlineUsers?.map((user) => {
             return (
               <div
-                // id가 없을 수 있어서 fallback key 사용
-                key={member.id ?? `${member.email}-${member.name}`}
+                key={user.id}
                 className="w-8 h-8 rounded-full border-2 border-white bg-slate-200 flex items-center justify-center text-xs font-bold shadow-sm relative group"
               >
-                {member.avatar}
-                {/* 유저별 현재 상태 배지 (StatusBadge 재사용) */}
+                <div className="w-full h-full rounded-full overflow-hidden flex items-center justify-center">
+                  {user.avatar.startsWith('http') || user.avatar.startsWith('/') ? (
+                    <img src={user.avatar} alt={user.name} className="w-full h-full object-cover" />
+                  ) : (
+                    <span>{user.avatar}</span>
+                  )}
+                </div>
+
+                {/* 유저별 현재 상태 배지: 훅에서 계산해준 statusColor를 바로 사용 */}
                 <div className="absolute -bottom-0.5 -right-0.5 z-10">
-                  <StatusBadge color={userStatus?.color} size="sm" />
+                  <StatusBadge color={user.statusColor} size="sm" />
                 </div>
 
                 {/* 툴팁: 마우스 호버 시 유저명과 상세 상태 표시 */}
                 <div className="absolute top-10 left-1/2 -translate-x-1/2 bg-slate-800 text-white text-[9px] px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl font-bold tracking-tighter">
-                  {member.name} ({userStatus?.label || '활동 중'})
+                  {user.name} ({user.status})
                 </div>
               </div>
             );
           })}
         </div>
 
-        {/* 오른쪽: 액션 버튼 섹션 (대시보드에서만 새 업무 발행 가능) */}
+        {/* 오른쪽: 액션 버튼 섹션 */}
         {view === 'dashboard' && (
           <button
-            onClick={() => {
-              console.log('새 요청 버튼 클릭됨');
-              setIsCreateModalOpen(true);
-            }}
+            onClick={() => setIsCreateModalOpen(true)}
             className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-black flex items-center gap-2 shadow-md active:scale-95 transition-all"
           >
             <Plus size={18} /> 새 요청

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -36,7 +36,7 @@ export const Sidebar = ({
   const [isStatusPickerOpen, setIsStatusPickerOpen] = useState(false);
 
   // 내 현재 상태 정보 가져오기 (기본값: 개발 중)
-  const myStatus = activeTeam?.userStatuses?.[currentUser.name] || { 
+  const myStatus = activeTeam?.userStatuses?.[currentUser.uuid] || { 
     label: '개발 중', 
     color: 'bg-green-500' 
   };

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -17,8 +17,10 @@ import type {
   TaskBaseFromApi,
   TaskComment,
   TaskCommentFromApi,
+  OnlineUserFromApi,
+  GetOnlineUsersResponse,
 } from '../types';
-import { INITIAL_TEAM, AVATARS } from '../utils/constants';
+import { INITIAL_TEAM, AVATARS, USER_ACTIVITIES } from '../utils/constants';
 import { getTeamsApi, joinTeamApi, leaveTeamApi } from '../api/team';
 import {
   deleteTicketApi,
@@ -50,14 +52,7 @@ import {
   DeleteCommentApi,
   updateCommentApi,
 } from '../api/comments';
-
-// 상태별 색 매핑
-const STATUS_COLORS: Record<string, string> = {
-  '업무 중': 'bg-green-500',
-  '회의 중': 'bg-blue-500',
-  '쉬는 중': 'bg-orange-500',
-  '자리 비움': 'bg-slate-400',
-};
+import { getOnlineUsersApi } from "../api/member";
 
 // 로그의 액션 타입에 따라 UI 색상을 결정하는 헬퍼 함수
 const getLogDisplayType = (
@@ -102,12 +97,14 @@ const convertTeam = (team: TeamFromApi): Team => ({
   links: [],
   userStatuses: Object.fromEntries(
     team.members.map((m) => {
-      const statusLabel = m.status || '업무 중'; // 기본값 설정
+      const statusLabel = m.status || '업무 중';
+      const matched = USER_ACTIVITIES.find(a => a.label === statusLabel);
       return [
-        m.user.name,
-        {
+
+        m.user.uuid,
+        { 
           label: statusLabel,
-          color: STATUS_COLORS[statusLabel] || 'bg-green-500',
+          color: matched?.color || 'bg-green-500' 
         },
       ];
     }),
@@ -140,6 +137,16 @@ export const useTeams = (
     queryKey: ['teams'],
     queryFn: getTeamsApi,
     enabled: !!currentUser,
+  });
+
+  // 활동 중인 팀원 목록 전용 쿼리
+  const { data: onlineUsersData } = useQuery<GetOnlineUsersResponse>({
+    queryKey: ['onlineUsers', activeTeamId],
+    queryFn: () => {
+      console.log("🚀 온라인 유저 API 호출 시도! 팀 ID:", activeTeamId);
+      return getOnlineUsersApi(Number(activeTeamId));
+    },
+    enabled: !!activeTeamId && activeTeamId !== '0',
   });
 
   // 활성화된 팀의 테스크 목록 조회
@@ -197,6 +204,7 @@ export const useTeams = (
     teamChannel.bind('status-updated', () => {
       queryClient.invalidateQueries({ queryKey: ['teams'] });
       queryClient.invalidateQueries({ queryKey: ['logs', activeTeamId] });
+      queryClient.invalidateQueries({ queryKey: ['onlineUsers', activeTeamId] });
     });
 
     // 서버의 팀 목록 데이터를 무효화
@@ -467,6 +475,25 @@ export const useTeams = (
     }
   };
 
+  // 데이터 가공
+  const onlineUsers = useMemo(() => {
+  // 여기서 onlineUsersData는 이제 GetOnlineUsersResponse 형식이 됩니다.
+  if (!onlineUsersData?.success || !onlineUsersData.data) return [];
+  
+    return onlineUsersData.data.map((item: OnlineUserFromApi) => {
+      const avatarIndex = item.id % AVATARS.length;
+      const matched = USER_ACTIVITIES.find(a => a.label === item.status);
+
+      return {
+        id: item.id,
+        name: item.user.name,
+        avatar: item.user.profile_image || AVATARS[avatarIndex],
+        status: item.status, 
+        statusColor: matched?.color || 'bg-green-500'
+      };
+    });
+  }, [onlineUsersData]);
+
   // task 상태 변경
   const updateTicketStatus = async (
     taskId: number,
@@ -730,6 +757,7 @@ export const useTeams = (
     isTeamNameTaken,
     isValidTeamPassword,
     createTeam,
+    onlineUsers,
     joinTeam,
     updateTicketStatus,
     handleCreateTicket,

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -19,7 +19,7 @@ import type {
   TaskCommentFromApi,
 } from '../types';
 import { INITIAL_TEAM, AVATARS } from '../utils/constants';
-import { getTeamsApi, joinTeamApi } from '../api/team';
+import { getTeamsApi, joinTeamApi, leaveTeamApi } from '../api/team';
 import {
   deleteTicketApi,
   getTicketDetailApi,
@@ -631,11 +631,24 @@ export const useTeams = (
   /**
    * [기능] leaveTeam: 현재 유저를 팀 멤버 목록에서 제거
    */
-  const leaveTeam = async () => {
-    await queryClient.invalidateQueries({ queryKey: ['teams'] });
-    setActiveTeamId(null);
-  };
+  const leaveTeam = async (teamId: number) => {
+    try {
+      const response = await leaveTeamApi(teamId);
 
+      if (response.success) {
+        // 가입된 팀 목록이 바뀌었으므로 서버 데이터를 새로고침
+        await queryClient.invalidateQueries({ queryKey: ['teams'] });
+        
+        // 현재 활성화된 팀 ID 정보 삭제
+        setActiveTeamId(null);
+        return { ok: true };
+      }
+      return { ok: false, message: response.error || '탈퇴 처리 실패' };
+    } catch (error) {
+      console.error('탈퇴 API 호출 에러:', error);
+      throw error;
+    }
+  };
   // 내 포지션 수정
   const handleEditPosition = async (newPosition: string) => {
     if (!activeTeamId || !currentUser) return;

--- a/src/pages/Members.tsx
+++ b/src/pages/Members.tsx
@@ -17,9 +17,12 @@ export const Members = ({
       {activeTeam.members.map((member) => {
         const isMe = member.email === currentUser.email; // uuid 대신 email로 비교
 
+        // uuid로 실시간 상태 가져오는 역할
+        const currentStatus = activeTeam.userStatuses[member.uuid];
+
         return (
           <div
-            key={member.id ?? `${member.email}-${member.name}`}
+            key={member.id ?? member.uuid}
             className="bg-white p-8 rounded-[40px] border border-slate-200 shadow-sm flex flex-col items-center"
           >
             {/* 아바타 섹션 */}
@@ -43,7 +46,7 @@ export const Members = ({
               </div>
               <span
                 className={`absolute -bottom-1.25 -right-1.25 w-5 h-5 border-4 border-white rounded-full ${
-                  activeTeam.userStatuses[member.name]?.color ?? 'bg-green-500'
+                  activeTeam.userStatuses[member.uuid]?.color ?? 'bg-green-500'
                 }`}
               />
             </div>
@@ -70,10 +73,10 @@ export const Members = ({
             <div className="text-[10px] font-bold text-slate-400 mb-6 flex items-center gap-1.5">
               <span
                 className={`w-1.5 h-1.5 rounded-full ${
-                  activeTeam.userStatuses[member.id!]?.color ?? 'bg-green-500'
+                  currentStatus?.color ?? 'bg-green-500'
                 }`}
               />
-              {activeTeam.userStatuses[member.id!]?.label ?? '활동 중'}
+              {currentStatus?.label ?? '활동 중'}
 
               {member.github && (
                 <div className="flex items-center gap-1.5">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,26 @@ export interface Member {
   github: string;
 }
 
+// 활동 중인 유저 정보 : 서버 응답
+export interface OnlineUserFromApi {
+  id: number;
+  position: string;
+  status: string;
+  user: {
+    uuid: string;
+    name: string;
+    profile_image: string | null;
+  };
+}
+
+// api 전체 응답 구조
+export interface GetOnlineUsersResponse {
+  success: boolean;
+  data: OnlineUserFromApi[] | null;
+  meta: null;
+  error: string | null;
+}
+
 // 티켓 내부 댓글 구조
 export interface Comment {
   id: number;


### PR DESCRIPTION
- [x] 사이드바 팀 탈퇴 버튼에 팀 탈퇴 api 연결
- [x] 활동중인 팀원 목록 조회 api 연동

## 수정 사항
- [x] 활동중인 팀원 목록 조회 시, 헤더에서 자리비움 사람만 빠지도록 수정
- [x] 동명이인의 상태 변경이 함께 바뀌는 문제 -> 이름 대신 UUID 기준으로 상태 업데이트하도록 변경