### PR TITLE
[jh_bug/#76] 로그, 상태, 칸반보드 버튼 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import type { AxiosError } from 'axios';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createTeamApi, joinTeamApi } from './api/team';
@@ -31,6 +31,7 @@ import { Modal } from './components/ui/Modal';
 import { useTeams } from './hooks/useTeams';
 import { type Member, type CurrentUser, type TeamArchiveData } from './types';
 import { validateUrl } from './utils/validation';
+import { updateMyStatusApi } from "./api/status";
 
 export default function App() {
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
@@ -167,6 +168,17 @@ export default function App() {
   // 로그아웃 API 호출
   const logoutMutation = useMutation({ mutationFn: logoutApi });
 
+  // 공통 상태 업데이트 헬퍼 함수
+  const syncUserStatus = useCallback(async (teamId: number, status: string) => {
+    try {
+      await updateMyStatusApi(teamId, status);
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
+      queryClient.invalidateQueries({ queryKey: ['onlineUsers', String(teamId)] });
+    } catch (err) {
+      console.warn(`[Status Sync] ${status} 업데이트 실패:`, err);
+    }
+  }, [queryClient]);
+
   // 팀 생성 API 호출
   const createTeamMutation = useMutation({
     mutationFn: createTeamApi,
@@ -189,9 +201,13 @@ export default function App() {
   const joinTeamMutation = useMutation({
     mutationFn: ({ teamId, data }: { teamId: string; data: JoinTeamRequest }) =>
       joinTeamApi(teamId, data),
-    onSuccess: (data) => {
+    onSuccess: async (data, variables) => {
       if (data && (data.success || data.data)) {
         console.log('팀 입장 성공!');
+
+        // 입장한 팀에 '업무 중'으로 상태 업데이트
+        await syncUserStatus(Number(variables.teamId), '업무 중');
+
         if (pendingTeamId) {
           setActiveTeamId(pendingTeamId);
         }
@@ -250,15 +266,21 @@ export default function App() {
 
       const lastTeamId = localStorage.getItem('lastTeamId');
       const wasAuthorized = localStorage.getItem('isTeamAuthorized') === 'true';
-      if (lastTeamId && wasAuthorized) {
-        setActiveTeamId(lastTeamId);
-        setIsTeamAuthorized(true);
+
+      // [로그인 시 자동 처리] 세션 복원 시 마지막 활성 팀을 '업무 중'으로 변경
+      if (lastTeamId) {
+        syncUserStatus(Number(lastTeamId), '업무 중');
+        
+        if (wasAuthorized) {
+          setActiveTeamId(lastTeamId);
+          setIsTeamAuthorized(true);
+        }
       }
     }
     if (!isUserLoading) {
       setIsAuthLoading(false);
     }
-  }, [userData, isUserLoading, setActiveTeamId]);
+  }, [userData, isUserLoading, setActiveTeamId, queryClient, syncUserStatus]);
 
   // --- 세션 유지 로직 ---
   useEffect(() => {
@@ -691,6 +713,15 @@ export default function App() {
   // 공통 로그아웃 처리
   const handleLogout = async () => {
     try {
+      // 로그아웃 시, '자리 비움'으로 상태 변경
+      if (activeTeamId) {
+        try {
+          await syncUserStatus(Number(activeTeamId), '자리 비움');
+        } catch (err) {
+          console.warn("로그아웃 상태 업데이트 실패 (무시하고 로그아웃 진행):", err);
+        }
+      }
+
       const data = await logoutMutation.mutateAsync();
       if (!data.success) {
         alert(data.error || '로그아웃에 실패했습니다.');
@@ -714,6 +745,11 @@ export default function App() {
     } catch (error) {
       console.log(error);
       alert('로그아웃에 실패했습니다.');
+      // 토큰 만료 시, 내 브라우저에서 자리비움 처리
+      setCurrentUser(null);
+      setActiveTeamId(null);
+      setIsTeamAuthorized(false);
+      setAuthPage('login');
     }
   };
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -113,12 +113,18 @@ export const Sidebar = ({
           <div className="space-y-3 max-h-40 overflow-y-auto pr-1 scrollbar-hide min-h-40">
           {displayLogs.length > 0 ? (
               displayLogs.map((log) => {
-                const style = LOG_STYLES[log.type as keyof typeof LOG_STYLES] || LOG_STYLES.default;
+                console.log("로그 타입 확인:", log.type);
+                const currentType = (log.type && LOG_STYLES[log.type as keyof typeof LOG_STYLES]) 
+                  ? (log.type as keyof typeof LOG_STYLES) 
+                  : 'default';
+                const style = LOG_STYLES[currentType];
 
       return (
-        <div key={log.id} className={`relative pl-3 border-l ${style.border} ${style.bg} transition-all py-1`}>
+        <div 
+          key={log.id} 
+          className={`relative pl-3 border-l ${style.border} ${style.bg} transition-all py-2 rounded-r-lg`}>
           {/* 상태 변경 점 색상 적용 */}
-          <div className={`absolute left-[-3.5px] top-2 w-1.5 h-1.5 rounded-full ${style.dot}`} />
+          <div className={`absolute -left-1.25 top-3 w-2 h-2 rounded-full ${style.dot} ring-2 ring-white `} />
           
           <div className="flex justify-between items-start leading-none mb-1">
             <span className="text-[10px] font-bold text-slate-700">{log.user}</span>
@@ -126,14 +132,20 @@ export const Sidebar = ({
           </div>
           
           {/* 텍스트 색상 적용 */}
-          <p className={`text-[9px] truncate ${style.text} font-medium`}>
-            <span className="opacity-70 mr-1">
+          <p className={`text-[11px] leading-snug ${style.text} font-bold wrap-break-word`}>
+            <span className="opacity-60 mr-1 text-[10px] font-mono">
               {log.ticketId > 0 && !log.action.includes('#') 
                 ? `#${String(log.ticketId).replace('#', '')}` 
-                : (log.ticketId === 0 ? 'Entry' : '')}
+                : (log.ticketId === 0 ? '[Entry]' : '')}
             </span>
             {log.action}
           </p>
+            {/* 시간 */}
+            {/* <div className="flex justify-end mt-1">
+              <span className="text-[9px] font-mono text-slate-400 opacity-80">
+                {log.time}
+              </span>
+            </div> */}
         </div>
       );
     })

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -113,7 +113,6 @@ export const Sidebar = ({
           <div className="space-y-3 max-h-40 overflow-y-auto pr-1 scrollbar-hide min-h-40">
           {displayLogs.length > 0 ? (
               displayLogs.map((log) => {
-                console.log("로그 타입 확인:", log.type);
                 const currentType = (log.type && LOG_STYLES[log.type as keyof typeof LOG_STYLES]) 
                   ? (log.type as keyof typeof LOG_STYLES) 
                   : 'default';

--- a/src/components/task/KanbanBoard.tsx
+++ b/src/components/task/KanbanBoard.tsx
@@ -1,9 +1,10 @@
-import type { Ticket, StatusType } from '../../types';
+import type { Ticket, StatusType, CurrentUser } from '../../types';
 import { TicketCard } from './TicketCard';
 
 interface KanbanColumnProps {
   status: StatusType; // 컬럼의 상태 정보 (ID, 라벨, 아이콘, 색상 등 포함)
   tickets: Ticket[]; // 이 컬럼의 상태와 일치하도록 부모(Dashboard)에서 필터링되어 넘어온 티켓들
+  currentUser: CurrentUser;
   onTicketClick: (id: number) => void; // 티켓 클릭 시 상세 모달을 띄우기 위한 핸들러
   updateTicketStatus: (
     taskId: number, 
@@ -11,7 +12,7 @@ interface KanbanColumnProps {
   ) => Promise<{ ok: boolean } | undefined>; // 티켓 상태 변경(반려 포함) 로직
 }
 
-export const KanbanColumn = ({ status, tickets, onTicketClick, updateTicketStatus }: KanbanColumnProps) => {
+export const KanbanColumn = ({ status, tickets, currentUser, onTicketClick, updateTicketStatus }: KanbanColumnProps) => {
   // 상태 정보에서 아이콘 컴포넌트를 추출
   const Icon = status.icon;
 
@@ -33,6 +34,7 @@ export const KanbanColumn = ({ status, tickets, onTicketClick, updateTicketStatu
         {tickets.map((ticket) => (
           <TicketCard
             key={ticket.id}
+            currentUser={currentUser}
             ticket={ticket}
             status={status}
             onClick={() => onTicketClick(ticket.id)}

--- a/src/components/task/TicketCard.tsx
+++ b/src/components/task/TicketCard.tsx
@@ -1,9 +1,10 @@
 import { Clock, ChevronRight } from 'lucide-react';
-import type { Ticket, StatusType } from '../../types';
+import type { Ticket, StatusType, CurrentUser } from '../../types';
 
 interface TicketCardProps {
   ticket: Ticket;
   status: StatusType;
+  currentUser: CurrentUser;
   onClick: () => void;
   updateTicketStatus: (
     taskId: number, 
@@ -11,7 +12,27 @@ interface TicketCardProps {
   ) => Promise<{ ok: boolean } | undefined>;
 }
 
-export const TicketCard = ({ ticket, status, onClick, updateTicketStatus }: TicketCardProps) => {
+export const TicketCard = ({ ticket, status, currentUser, onClick, updateTicketStatus }: TicketCardProps) => {
+
+  // 권한 체크
+  const isWorker = String(currentUser?.uuid) === String(ticket.worker_id);
+  const isRequester = String(currentUser?.uuid) === String(ticket.requester_id);
+
+  console.log('유저 UUID:', currentUser?.uuid, typeof currentUser?.uuid);
+  console.log('담당자 ID:', ticket.worker_id, typeof ticket.worker_id);
+  console.log('일치 여부:', isWorker);
+
+  // 현재 버튼 클릭 가능 여부 판단
+  let canClickNext = false;
+  if (ticket.status === 'Todo' || ticket.status === 'Doing') {
+    canClickNext = isWorker;
+  } else if (ticket.status === 'Done') {
+    canClickNext = isRequester;
+  }
+
+  // 비활성화 시 공통 스타일
+  const disabledStyle = "bg-slate-100 text-slate-400 cursor-not-allowed shadow-none opacity-60 hover:bg-slate-100 active:scale-100";
+
   return (
     <div
       onClick={() => {
@@ -40,17 +61,23 @@ export const TicketCard = ({ ticket, status, onClick, updateTicketStatus }: Tick
             {/* 반려 버튼 */}
             {status.back && (
               <button
+                disabled={!isRequester}
                 onClick={(e) => {
                   e.stopPropagation();
                   updateTicketStatus(ticket.id, 'reject');
                 }}
-                className="px-3 py-1.5 bg-red-50 text-red-600 text-[10px] font-black rounded-xl hover:bg-red-100 transition-all"
+                className={`px-3 py-1.5 text-[10px] font-black rounded-xl transition-all ${
+                  isRequester 
+                    ? "bg-red-50 text-red-600 hover:bg-red-100"
+                    : disabledStyle
+                }`}
               >
                 반려
               </button>
             )}
             {/* 단계 별 버튼 (수락/제출/승인) */}
             <button
+              disabled={!canClickNext}
               onClick={(e) => {
                 e.stopPropagation();
 
@@ -63,7 +90,11 @@ export const TicketCard = ({ ticket, status, onClick, updateTicketStatus }: Tick
 
                 updateTicketStatus(ticket.id, action);
               }}
-              className="px-4 py-2 bg-blue-600 text-white text-[10px] font-black rounded-xl shadow-lg shadow-blue-200 hover:bg-blue-700 flex items-center gap-1 active:scale-95 transition-all"
+              className={`px-4 py-2 text-[10px] font-black rounded-xl flex items-center gap-1 transition-all ${
+                canClickNext 
+                  ? "bg-blue-600 text-white shadow-lg shadow-blue-200 hover:bg-blue-700 active:scale-95"
+                  : disabledStyle
+              }`}
             >
               {status.nextLabel} <ChevronRight size={12} />
             </button>

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -332,6 +332,7 @@ export const useTeams = (
             content: task.content,
             status: task.status || 'Todo',
             requester: task.requester_name,
+            requester_id: String(task.requester_id),
             worker: task.worker_name,
             worker_id: String(task.worker_id),
             createdAt: task.created_at?.split('T')[0] || '',

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -56,19 +56,11 @@ import { getOnlineUsersApi } from "../api/member";
 
 // 로그의 액션 타입에 따라 UI 색상을 결정하는 헬퍼 함수
 const getLogDisplayType = (
-  actionType: string,
-  message: string,
+  actionType: string
 ): 'default' | 'info' | 'success' | 'error' => {
-  if (actionType === 'CREATE_TASK' || actionType === 'ACCEPT_TASK')
-    return 'info';
-  if (actionType === 'APPROVE_TASK' || actionType === 'STATUS_CHANGE')
-    return 'success';
-  if (actionType === 'REJECT_TASK' || actionType === 'CANCEL_TASK')
-    return 'error';
-
-  // 타입이 명확하지 않을 때 메시지 내용으로 한 번 더 체크
-  if (message.includes('반려') || message.includes('취소')) return 'error';
-  if (message.includes('상태') || message.includes('승인')) return 'success';
+  if (actionType === 'CREATE') return 'info'; 
+  if (actionType === 'MOVE') return 'success';
+  if (actionType === 'DELETE') return 'error';
 
   return 'default';
 };
@@ -367,7 +359,7 @@ export const useTeams = (
           time: new Date(log.created_at).toLocaleTimeString('ko-KR', {
             hour12: false,
           }),
-          type: getLogDisplayType(log.action_type, log.message),
+          type: getLogDisplayType(log.action_type),
         }),
       );
     }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -22,6 +22,7 @@ interface DashboardProps {
 export const Dashboard = ({
   activeTeam,
   activeTeamId,
+  currentUser,
   setSelectedTicketId,
   updateTicketStatus,
   activeModal,
@@ -195,6 +196,7 @@ export const Dashboard = ({
                 <KanbanColumn
                   key={status.id}
                   status={status}
+                  currentUser={currentUser}
                   tickets={filteredTickets}
                   onTicketClick={setSelectedTicketId}
                   updateTicketStatus={updateTicketStatus}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Ticket {
   title: string;
   content: string;
   requester: string;
+  requester_id: string;
   worker: string;
   worker_id: string;
   status: string;


### PR DESCRIPTION
## 수정 사항
- [x] 사이드바에서 로그 폰트 키우고, 시간을 아래에 출력하도록 변경
- [x] api 응답 중 action_type으로 로그 색상 매핑
- [x] 칸반보드에서 권한에 따른 버튼 활성화 
- [x] 로그인 시, 자동으로 상태 '업무 중', 로그아웃 시, 자동으로 '자리 비움' 처리

[로그인, 로그아웃 처리]
1. 로그인 시에, 마지막으로 활동했던 팀에는 업무 중으로 처리가 됨
2. 다른 팀에 입장 시, 마지막으로 활동했던 팀에서 상태 유지하며 다른 팀에도 업무 중으로 변경 ⇒ 마지막으로 활동했던 팀을 로그아웃 처리하는 것보다는 상태를 계속 유지하면서 로그아웃 시에 모든 팀에서 자리비움 처리를 하는 게 좀 더 효율적이라고 판단
3. 로그아웃과 토큰 만료 시에 자리비움으로 변경

<img width="3420" height="1902" alt="image" src="https://github.com/user-attachments/assets/0e22e10b-c83f-4b59-87cd-597eb36c419b" />
