### PR TITLE
[FEAT] #95 /teams 로비용 조회 수정

### DIFF
--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -94,12 +94,9 @@ const getLogDisplayType = (
 };
 
 // API 응답 TeamFromApi → 기존 Team 타입으로 변환하는 함수
-const convertTeam = (team: TeamFromApi): Team => ({
-  id: String(team.id),
-  name: team.name,
-  password: '',
-  isMember: team.isMember,
-  members: team.members
+const convertTeam = (team: TeamFromApi): Team => {
+  // 기존 members 응답이 있으면 그대로 사용
+  const mappedMembers = (team.members ?? [])
     .map((m) => {
       const user = m.user as typeof m.user & {
         profile_image_url?: unknown;
@@ -129,25 +126,52 @@ const convertTeam = (team: TeamFromApi): Team => ({
         github: user.github_url || '',
       };
     })
-    .sort((a, b) => Number(a.id) - Number(b.id)),
-  tickets: [],
-  logs: [],
-  notes: [],
-  links: [],
-  userStatuses: Object.fromEntries(
-    team.members.map((m) => {
-      const statusLabel = m.status || '업무 중';
-      const matched = USER_ACTIVITIES.find((a) => a.label === statusLabel);
-      return [
-        m.user.uuid,
-        {
-          label: statusLabel,
-          color: matched?.color || 'bg-green-500',
-        },
-      ];
-    }),
-  ),
-});
+    .sort((a, b) => Number(a.id) - Number(b.id));
+
+  // 로비용 응답이면 previewImages를 화면 표시용 members 형태로만 보정
+  const previewMembers =
+    mappedMembers.length > 0
+      ? mappedMembers
+      : (team.previewImages ?? []).map((image, index) => ({
+          id: index + 1,
+          uuid: `preview-${team.id}-${index}`,
+          name: `preview-${index}`,
+          position: '',
+          avatar: image,
+          email: '',
+          phone: '',
+          github: '',
+        }));
+
+  return {
+    id: String(team.id),
+    name: team.name,
+    password: '',
+    isMember: team.isMember,
+    memberCount: team.memberCount ?? previewMembers.length,
+    previewImages:
+      team.previewImages ??
+      previewMembers.map((m) => m.avatar || '').filter(Boolean),
+    members: previewMembers,
+    tickets: [],
+    logs: [],
+    notes: [],
+    links: [],
+    userStatuses: Object.fromEntries(
+      (team.members ?? []).map((m) => {
+        const statusLabel = m.status || '업무 중';
+        const matched = USER_ACTIVITIES.find((a) => a.label === statusLabel);
+        return [
+          m.user.uuid,
+          {
+            label: statusLabel,
+            color: matched?.color || 'bg-green-500',
+          },
+        ];
+      }),
+    ),
+  };
+};
 
 /**
  * 특정 팀의 데이터를 최신 상태로 갈아끼워주는 헬퍼 함수
@@ -498,6 +522,7 @@ export const useTeams = (
   const joinedTeams = useMemo(() => {
     if (!currentUser) return [];
     return teams.filter((team) =>
+      team.isMember === true ||
       team.members.some((member) => member.name === currentUser.name),
     );
   }, [teams, currentUser]);
@@ -507,6 +532,7 @@ export const useTeams = (
     if (!currentUser) return teams;
     return teams.filter(
       (team) =>
+        team.isMember !== true &&
         !team.members.some((member) => member.name === currentUser.name),
     );
   }, [teams, currentUser]);

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -38,12 +38,9 @@ const getAvatarValue = (value: unknown) => {
 }
 
 // API 응답 TeamFromApi → 기존 Team 타입으로 변환하는 함수
-const convertTeam = (team: TeamFromApi): Team => ({
-  id: String(team.id),
-  name: team.name,
-  password: '',
-  isMember: team.isMember,
-  members: team.members.map((m) => {
+const convertTeam = (team: TeamFromApi): Team => {
+  // 기존 members 응답이 있으면 그대로 사용
+  const mappedMembers = (team.members ?? []).map((m) => {
     const user = m.user as typeof m.user & {
       profile_image_url?: unknown
       profileImage?: unknown
@@ -70,18 +67,43 @@ const convertTeam = (team: TeamFromApi): Team => ({
       phone: user.phone,
       github: user.github_url || '',
     }
-  }),
-  tickets: [],
-  logs: [],
-  notes: [],
-  links: [],
-  userStatuses: Object.fromEntries(
-    team.members.map((m) => [
-      m.user.name,
-      { label: m.status || '활동 중', color: 'bg-green-500' }
-    ])
-  ),
-})
+  })
+
+  // 로비용 응답이면 previewImages를 화면 표시용 members 형태로만 보정
+  const previewMembers =
+    mappedMembers.length > 0
+      ? mappedMembers
+      : (team.previewImages ?? []).map((image, index) => ({
+          id: index + 1,
+          uuid: `preview-${team.id}-${index}`,
+          name: `preview-${index}`,
+          position: '',
+          avatar: image,
+          email: '',
+          phone: '',
+          github: '',
+        }))
+
+  return {
+    id: String(team.id),
+    name: team.name,
+    password: '',
+    isMember: team.isMember,
+    memberCount: team.memberCount ?? previewMembers.length,
+    previewImages: team.previewImages ?? previewMembers.map((m) => m.avatar || '').filter(Boolean),
+    members: previewMembers,
+    tickets: [],
+    logs: [],
+    notes: [],
+    links: [],
+    userStatuses: Object.fromEntries(
+      (team.members ?? []).map((m) => [
+        m.user.name,
+        { label: m.status || '활동 중', color: 'bg-green-500' }
+      ])
+    ),
+  }
+}
 
 export const Lobby = ({
   currentUser,
@@ -208,7 +230,7 @@ export const Lobby = ({
             {team.name}
           </h3>
           <p className="mt-1 flex items-center gap-1 text-[11px] font-semibold text-slate-400">
-            <Users size={12} /> {team.members.length}명의 멤버
+            <Users size={12} /> {team.memberCount ?? team.members.length}명의 멤버
           </p>
         </div>
       </div>
@@ -217,7 +239,15 @@ export const Lobby = ({
       <div className="pt-5 border-t border-slate-100 space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex -space-x-2">
-            {team.members.slice(0, 3).map((m) => (
+            {(team.previewImages && team.previewImages.length > 0
+                ? team.previewImages.slice(0, 3).map((image, index) => ({
+                    id: index + 1,
+                    avatar: image,
+                    name: `preview-${index}`,
+                    email: `preview-${index}`,
+                  }))
+                : team.members.slice(0, 3)
+              ).map((m) => (
               <div
                 key={m.id ?? `${m.email}-${m.name}`}
                 className="w-7 h-7 rounded-full border-2 border-white bg-slate-100 flex items-center justify-center text-[10px] font-bold shadow-sm overflow-hidden"
@@ -231,7 +261,7 @@ export const Lobby = ({
                 ) : m.avatar ? (
                   <span className="text-sm">{m.avatar}</span>
                 ) : (
-                  m.name.slice(0, 1)
+                  m.name?.slice(0, 1) || '?'
                 )}
               </div>
             ))}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,6 +196,8 @@ export interface Team {
   name: string;
   password: string;
   isMember?: boolean;
+  memberCount?: number; // 로비용 멤버 수
+  previewImages?: string[]; // 로비용 미리보기 이미지
   members: Member[];
   tickets: Ticket[];
   logs: Log[];
@@ -242,9 +244,11 @@ export interface TeamMemberFromApi {
 export interface TeamFromApi {
   id: number;
   name: string;
-  owner_id: string;
+  owner_id?: string;
   isMember: boolean;
-  members: TeamMemberFromApi[];
+  memberCount?: number;
+  previewImages?: string[];
+  members?: TeamMemberFromApi[];
 }
 
 // GET /teams 로비용 조회 전체 응답 타입


### PR DESCRIPTION
/teams 는 이렇게 되어있습니다. (첫번째사진)
---
<img width="1752" height="1188" alt="image" src="https://github.com/user-attachments/assets/40af3220-219b-4a1c-b765-236dde350dab" />

설명
---
이 상태에서 저번에 멘토링 때 받은 피드백은,
로비에서 개발자도구를 키면 다른 팀의 멤버까지 다 보이는 상황이라
아예 이 API에서 제가 body로 보내드리는 걸 두번째사진 처럼 보이도록 수정했습니다

지금 현재 /teams 는 이렇게 수정을 했습니다.
---
<img width="811" height="579" alt="image" src="https://github.com/user-attachments/assets/449c7fa0-d2a9-42c0-b0a3-fa679966ecc4" />

