### PR TITLE
[jh_feat/#97] pusher 리스너 추가

### DIFF
--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -283,6 +283,21 @@ export const useTeams = (
       refreshTeamData();
     });
 
+    // 테스크 생성 알림 (모든 팀원 대상)
+    teamChannel.bind('task-created', () => {
+      refreshTeamData();
+    });
+
+    // 테스크 내용 수정 알림
+    teamChannel.bind('task-updated', () => {
+      refreshTeamData();
+    });
+
+    // 테스크 삭제 알림
+    teamChannel.bind('task-deleted', () => {
+      refreshTeamData();
+    });
+
     // 개인별 테스크 할당 알림 리스너
     userChannel.bind('new-task-requested', () => {
       refreshTeamData();
@@ -291,6 +306,9 @@ export const useTeams = (
     return () => {
       pusher.unsubscribe(`team-${activeTeamId}`);
       pusher.unsubscribe(`user-${currentUser.uuid}`);
+      // 등록된 모든 바인딩 해제 (메모리 누수 방지)
+      teamChannel.unbind_all();
+      userChannel.unbind_all();
     };
   }, [activeTeamId, currentUser, queryClient]);
 


### PR DESCRIPTION
로그 실시간 반영을 위한 pusher 리스너 추가

- [x] task-created → 칸반 보드에 새 카드 추가
- [x] task-updated → 해당 카드 내용 갱신
- [x] task-deleted → 해당 카드 제거