### PR TITLE
[bs_faet/#100] 구글 로그인 분기 및 팀 로비 이미지 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -673,19 +673,44 @@ export default function App() {
   };
 
   const handleLeaveTeam = async (teamId: string | number | null) => {
-  if (!teamId) return;
-  try {
-    await leaveTeam(Number(teamId));
+    if (!teamId) return;
 
+    // 낙관적 업데이트용 이전 상태 저장
+    const prevActiveTeamId = activeTeamId;
+    const prevIsTeamAuthorized = isTeamAuthorized;
+    const prevView = view;
+
+    try {
+      // 팀 탈퇴 버튼 클릭 시 즉시 팀 로비로 이동
       setIsTeamAuthorized(false);
       setActiveTeamId(null);
       setView('dashboard');
+      localStorage.removeItem('lastTeamId');
+      localStorage.setItem('isTeamAuthorized', 'false');
+      localStorage.setItem('currentView', 'dashboard');
+
+      await leaveTeam(Number(teamId));
 
       setTimeout(() => {
         alert('팀 탈퇴가 완료되었습니다.');
       }, 100);
     } catch (error: unknown) {
       console.error('탈퇴 처리 중 오류:', error);
+
+      // 탈퇴 실패 시 이전 상태로 복구
+      setIsTeamAuthorized(prevIsTeamAuthorized);
+      setActiveTeamId(prevActiveTeamId);
+      setView(prevView);
+
+      if (prevActiveTeamId) {
+        localStorage.setItem('lastTeamId', String(prevActiveTeamId));
+      }
+      localStorage.setItem(
+        'isTeamAuthorized',
+        String(prevIsTeamAuthorized),
+      );
+      localStorage.setItem('currentView', prevView);
+
       alert('팀 탈퇴 처리 중 문제가 발생했습니다.');
     }
   };
@@ -741,11 +766,7 @@ export default function App() {
         alert(data.error || '로그아웃에 실패했습니다.');
         return;
       }
-      if (data.data?.message) {
-        alert(data.data.message);
-      } else {
-        alert('로그아웃 되었습니다.');
-      }
+      
       setCurrentUser(null);
       setActiveTeamId(null);
       setIsTeamAuthorized(false);
@@ -756,9 +777,7 @@ export default function App() {
       setIsAuthManualEditing(false);
       setShowAuthPassword(false);
       setAuthPage('login');
-    } catch (error) {
-      console.log(error);
-      alert('로그아웃에 실패했습니다.');
+    } catch {
       // 토큰 만료 시, 내 브라우저에서 자리비움 처리
       setCurrentUser(null);
       setActiveTeamId(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -691,9 +691,6 @@ export default function App() {
 
       await leaveTeam(Number(teamId));
 
-      setTimeout(() => {
-        alert('팀 탈퇴가 완료되었습니다.');
-      }, 100);
     } catch (error: unknown) {
       console.error('탈퇴 처리 중 오류:', error);
 

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -99,17 +99,17 @@ const convertTeam = (team: TeamFromApi): Team => {
   const mappedMembers = (team.members ?? [])
     .map((m) => {
       const user = m.user as typeof m.user & {
-        profile_image_url?: unknown;
-        profileImage?: unknown;
-        avatar?: unknown;
-      };
+        profile_image_url?: unknown
+        profileImage?: unknown
+        avatar?: unknown
+      }
 
       // 서버에서 내려온 이미지 값 중 문자열만 사용
       const avatarImage =
         getAvatarValue(user.profile_image) ||
         getAvatarValue(user.profile_image_url) ||
         getAvatarValue(user.profileImage) ||
-        getAvatarValue(user.avatar);
+        getAvatarValue(user.avatar)
 
       return {
         id: m.id,
@@ -124,15 +124,21 @@ const convertTeam = (team: TeamFromApi): Team => {
         email: user.email,
         phone: user.phone,
         github: user.github_url || '',
-      };
+      }
     })
-    .sort((a, b) => Number(a.id) - Number(b.id));
+    .sort((a, b) => Number(a.id) - Number(b.id))
+
+  // previewImages도 깨진 랜덤 이미지 경로면 기본 아바타로 대체
+  const normalizedPreviewImages: string[] = (team.previewImages ?? []).map(
+    (image: string, index: number) =>
+      getAvatarValue(image) || getDefaultAvatar(`preview-${team.id}-${index}`)
+  )
 
   // 로비용 응답이면 previewImages를 화면 표시용 members 형태로만 보정
   const previewMembers =
     mappedMembers.length > 0
       ? mappedMembers
-      : (team.previewImages ?? []).map((image, index) => ({
+      : normalizedPreviewImages.map((image: string, index: number) => ({
           id: index + 1,
           uuid: `preview-${team.id}-${index}`,
           name: `preview-${index}`,
@@ -141,7 +147,7 @@ const convertTeam = (team: TeamFromApi): Team => {
           email: '',
           phone: '',
           github: '',
-        }));
+        }))
 
   return {
     id: String(team.id),
@@ -150,8 +156,9 @@ const convertTeam = (team: TeamFromApi): Team => {
     isMember: team.isMember,
     memberCount: team.memberCount ?? previewMembers.length,
     previewImages:
-      team.previewImages ??
-      previewMembers.map((m) => m.avatar || '').filter(Boolean),
+      normalizedPreviewImages.length > 0
+        ? normalizedPreviewImages
+        : previewMembers.map((m: { avatar?: string }) => m.avatar || '').filter(Boolean),
     members: previewMembers,
     tickets: [],
     logs: [],
@@ -159,19 +166,19 @@ const convertTeam = (team: TeamFromApi): Team => {
     links: [],
     userStatuses: Object.fromEntries(
       (team.members ?? []).map((m) => {
-        const statusLabel = m.status || '업무 중';
-        const matched = USER_ACTIVITIES.find((a) => a.label === statusLabel);
+        const statusLabel = m.status || '업무 중'
+        const matched = USER_ACTIVITIES.find((a) => a.label === statusLabel)
         return [
           m.user.uuid,
           {
             label: statusLabel,
             color: matched?.color || 'bg-green-500',
           },
-        ];
+        ]
       }),
     ),
-  };
-};
+  }
+}
 
 /**
  * 특정 팀의 데이터를 최신 상태로 갈아끼워주는 헬퍼 함수

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -69,11 +69,17 @@ const convertTeam = (team: TeamFromApi): Team => {
     }
   })
 
+  // previewImages도 그대로 쓰지 말고, 깨진 랜덤 이미지 경로면 기본 아바타로 대체
+  const normalizedPreviewImages: string[] = (team.previewImages ?? []).map(
+    (image: string, index: number) =>
+      getAvatarValue(image) || getDefaultAvatar(`preview-${team.id}-${index}`)
+  )
+
   // 로비용 응답이면 previewImages를 화면 표시용 members 형태로만 보정
   const previewMembers =
     mappedMembers.length > 0
       ? mappedMembers
-      : (team.previewImages ?? []).map((image, index) => ({
+      : normalizedPreviewImages.map((image: string, index: number) => ({
           id: index + 1,
           uuid: `preview-${team.id}-${index}`,
           name: `preview-${index}`,
@@ -90,7 +96,10 @@ const convertTeam = (team: TeamFromApi): Team => {
     password: '',
     isMember: team.isMember,
     memberCount: team.memberCount ?? previewMembers.length,
-    previewImages: team.previewImages ?? previewMembers.map((m) => m.avatar || '').filter(Boolean),
+    previewImages:
+      normalizedPreviewImages.length > 0
+        ? normalizedPreviewImages
+        : previewMembers.map((m: { avatar?: string }) => m.avatar || '').filter(Boolean),
     members: previewMembers,
     tickets: [],
     logs: [],
@@ -252,12 +261,27 @@ export const Lobby = ({
                 key={m.id ?? `${m.email}-${m.name}`}
                 className="w-7 h-7 rounded-full border-2 border-white bg-slate-100 flex items-center justify-center text-[10px] font-bold shadow-sm overflow-hidden"
               >
-                {m.avatar && m.avatar.startsWith('http') ? (
-                  <img
-                    src={m.avatar}
-                    alt={m.name}
-                    className="w-full h-full object-cover"
-                  />
+                {typeof m.avatar === 'string' &&
+                (m.avatar.startsWith('http') || m.avatar.startsWith('/')) ? (
+                  <>
+                    <img
+                      src={m.avatar}
+                      alt={m.name}
+                      className="w-full h-full object-cover"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none'
+                        const next =
+                          e.currentTarget.nextElementSibling as HTMLSpanElement | null
+                        if (next) next.style.display = 'flex'
+                      }}
+                    />
+                    <span
+                      className="w-full h-full items-center justify-center text-sm"
+                      style={{ display: 'none' }}
+                    >
+                      {getDefaultAvatar(m.email || m.name || String(m.id))}
+                    </span>
+                  </>
                 ) : m.avatar ? (
                   <span className="text-sm">{m.avatar}</span>
                 ) : (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -131,7 +131,6 @@ export const Login = ({ setCurrentUser, goSignup }: LoginProps) => {
           github: user.github || '',
         })
 
-        alert('구글 로그인 성공')
       } catch {
         alert('구글 로그인은 성공했지만 유저 정보 조회에 실패했습니다.')
       }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -114,6 +114,8 @@ export const Signup = ({ goLogin }: SignupProps) => {
       }
 
       setErrorMessage('')
+      // 회원가입 완료 안내 메시지
+      alert('회원가입이 완료되었습니다.')
       goLogin()
     },
     onError: (error) => {
@@ -203,6 +205,8 @@ export const Signup = ({ goLogin }: SignupProps) => {
 
       sessionStorage.removeItem('googleSignupUser')
       setErrorMessage('')
+      // 구글 회원가입 완료 안내 메시지
+      alert('구글 회원가입이 완료되었습니다.')
       goLogin()
     },
     onError: (error) => {

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -84,6 +84,8 @@ export const Signup = ({ goLogin }: SignupProps) => {
   const isNameValid = nameRegex.test(name.trim())
   const isPhoneValid = isPhonePrefixValid && isPhoneLengthValid
   const isEmailValid = emailRegex.test(email.trim())
+
+
   const isPasswordValid = passwordRegex.test(password)
 
   const isPasswordMatch = useMemo(() => {
@@ -112,7 +114,6 @@ export const Signup = ({ goLogin }: SignupProps) => {
       }
 
       setErrorMessage('')
-      alert('회원가입이 완료되었습니다.')
       goLogin()
     },
     onError: (error) => {
@@ -202,7 +203,6 @@ export const Signup = ({ goLogin }: SignupProps) => {
 
       sessionStorage.removeItem('googleSignupUser')
       setErrorMessage('')
-      alert('구글 회원가입이 완료되었습니다.')
       goLogin()
     },
     onError: (error) => {
@@ -414,11 +414,14 @@ export const Signup = ({ goLogin }: SignupProps) => {
                 } ${googleSignupUser ? 'opacity-70 cursor-not-allowed' : ''}`}
                 placeholder="mail@istation.dev"
               />
-              {email && !isEmailValid && (
-                <p className="text-xs text-red-400 ml-1">
-                  올바른 이메일 형식을 입력해주세요.
-                </p>
-              )}
+             {/* 구글 이메일 입력 시 일반 회원가입이 아닌 구글 로그인 안내 */}
+              {email &&
+                !googleSignupUser &&
+                /@(gmail\.com|googlemail\.com)$/i.test(email.trim()) && (
+                  <p className="text-xs text-red-400 ml-1">
+                    구글 이메일은 구글 로그인을 이용해 주세요.
+                  </p>
+                )}
             </div>
 
             {!googleSignupUser && (


### PR DESCRIPTION
## 작업 내용
- 일반 회원가입 시 구글 이메일 계정 입력 시 안내 문구가 표시되도록 수정
- 구글 로그인/회원가입이 백엔드의 기존 유저/신규 유저 판단 기준에 따라 분기되도록 동작 확인
- 구글 토큰 전달 및 유효성 검사 로직 반영 후 프론트 동작 확인
<img width="631" height="556" alt="image" src="https://github.com/user-attachments/assets/d9b5a7fd-46ee-4de8-bef6-d7a572caa697" />

- 팀 탈퇴 시 낙관적 업데이트로 즉시 팀 로비로 이동하도록 수정
- 회원가입, 로그인, 로그아웃 성공 alert 메시지 제거

---
- 팀 로비 페이지에 팀원 프로필에서 깨진 이미지
<img width="702" height="240" alt="스크린샷 2026-04-14 173514" src="https://github.com/user-attachments/assets/b67f02f9-771f-487b-a143-e10c74f11ed4" />

---
-  팀 로비에서 프로필 이미지가 없거나 깨지는 경우 기본 아바타로 대체되도록 수정
<img width="693" height="241" alt="image" src="https://github.com/user-attachments/assets/56047ee9-29e3-4f89-9123-d4ffb75be690" />

## 확인 사항
- 일반 회원가입에서 구글 이메일 입력 시 안내 문구가 표시되는지 확인
- 구글 로그인 시 기존 유저/신규 유저 분기가 정상 동작하는지 확인
- 팀 탈퇴 버튼 클릭 시 즉시 팀 로비로 이동하는지 확인
- 회원가입/로그인/로그아웃 시 성공 alert가 표시되지 않는지 확인
- 로비에서 깨진 프로필 이미지 대신 기본 아바타가 표시되는지 확인