### PR TITLE
[jh_bug/#99] 칸반보드 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 import type { AxiosError } from 'axios';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createTeamApi, joinTeamApi } from './api/team';
-import { type JoinTeamRequest } from './types';
+import { type GetMyInfoResponse, type JoinTeamRequest } from './types';
 import { Eye, EyeOff, Trash2 } from 'lucide-react';
 import { logoutApi, getMyInfoApi } from './api/auth';
 import {
@@ -239,7 +239,7 @@ export default function App() {
   });
 
   // 세션 복원 로직
-  const { data: userData, isLoading: isUserLoading } = useQuery({
+  const { data: userData, isLoading: isUserLoading } = useQuery<GetMyInfoResponse>({
     queryKey: ['myInfo'],
     queryFn: getMyInfoApi,
     staleTime: Infinity,
@@ -248,29 +248,30 @@ export default function App() {
   });
 
   useEffect(() => {
-  if (!userData) {
+  // 데이터가 없거나 실패면 중단
+  if (!userData?.success || !userData.data) {
     if (!isUserLoading) setIsAuthLoading(false);
     return;
   }
 
-  // 이름 복구 로직
-  const savedDisplayName = localStorage.getItem('displayName');
-  const restoredName = userData.name || savedDisplayName || userData.email?.split('@')[0] || '사용자';
+  const userRawData = userData.data;
 
-  if (userData.name) {
-    localStorage.setItem('displayName', userData.name);
-  }
-
-  // 유저 정보 업데이트
   setCurrentUser({
-    id: userData.id ?? Date.now(),
-    uuid: userData.uuid,
-    name: restoredName,
-    email: userData.email || '',
-    phone: userData.phone || '',
-    position: userData.position || '팀원',
-    github: userData.github || '',
+    ...userRawData,
+    id: userRawData.id,
+    uuid: userRawData.uuid,
+    name: userRawData.name || '사용자',
+    // ✅ 서버가 주는 profileImage를 avatar에 연결 (없으면 기본값 '')
+    avatar: userRawData.profileImage || '', 
+    email: userRawData.email || '',
+    phone: userRawData.phone || '',
+    position: userRawData.position || '팀원',
+    github: userRawData.github || '',
   });
+
+  if (userRawData.name) {
+    localStorage.setItem('displayName', userRawData.name);
+  }
 
   import('./utils/pusher').then(({ pusher }) => pusher.connect());
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,6 @@
 import type {
-  CurrentUser,
+  // CurrentUser,
+  GetMyInfoResponse,
   GoogleAuthRequest,
   GoogleAuthResponse,
   GoogleSignupRequest,
@@ -132,7 +133,7 @@ export const logoutApi = async (): Promise<LogoutResponse> => {
 }
 
 // 로그인한 유저 정보 조회 api 호출
-export const getMyInfoApi = async (): Promise<CurrentUser> => {
+export const getMyInfoApi = async (): Promise<GetMyInfoResponse> => {
   const response = await api.get('/users/me')
-  return response.data.data
+  return response.data
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -146,24 +146,34 @@ export const Header = ({
                       }`}
                     >
                       <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-1">
-                          {/* 읽지 않은 알림 New 표시 */}
-                          {noti.isNew && (
-                            <span className="w-1.5 h-1.5 bg-blue-600 rounded-full animate-pulse" />
-                          )}
-                          <p className={`text-[11px] leading-relaxed ${noti.isNew ? 'font-black text-slate-900' : 'font-bold text-slate-500'}`}>
-                            {noti.message}
-                          </p>
-                        </div>
-                        <span className="text-[9px] font-bold text-slate-300 uppercase">
-                          {new Date(noti.created_at).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+                      {/* 팀 이름 배지 추가 */}
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="px-2 py-0.5 bg-slate-100 text-slate-500 text-[9px] font-black rounded-md uppercase tracking-tighter border border-slate-200">
+                          Team : {noti.teamName || '알 수 없는 팀'}
                         </span>
+                        {/* 읽지 않은 알림 New 점 표시 */}
+                        {!noti.is_read && (
+                          <span className="w-1.5 h-1.5 bg-blue-600 rounded-full animate-pulse" />
+                        )}
                       </div>
-                      
-                      {noti.isNew && (
-                        <span className="text-[8px] font-black text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded-md h-fit">NEW</span>
-                      )}
+
+                      <div className="flex flex-col gap-0.5">
+                        <p className={`text-[11px] leading-relaxed ${!noti.is_read ? 'font-black text-slate-900' : 'font-bold text-slate-500'}`}>
+                          {noti.message}
+                        </p>
+                        
+                        <div className="flex items-center gap-2 mt-1">
+                          <span className="text-[9px] font-bold text-slate-300 uppercase">
+                            {new Date(noti.created_at).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+                          </span>
+                        </div>
+                      </div>
                     </div>
+                    
+                    {!noti.is_read && (
+                      <span className="text-[8px] font-black text-blue-600 bg-blue-100 px-1.5 py-0.5 rounded-md h-fit">NEW</span>
+                    )}
+                  </div>
                   ))
                 )}
               </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -71,6 +71,12 @@ export const Sidebar = ({
       updateProfileImage(formData);
     }
   };
+
+  // 1. 현재 팀원 목록에서 '나(이메일 기준)'를 찾습니다.
+const myInfoFromTeam = activeTeam?.members.find(m => m.email === currentUser?.email);
+
+// 2. 팀원 목록에 내가 있다면 그 사진(avatar)을 쓰고, 없으면 기존 정보를 씁니다.
+const finalAvatar = myInfoFromTeam?.avatar || currentUser?.avatar;
   
   return (
     <aside className="w-64 bg-white border-r border-slate-200 flex flex-col shrink-0">
@@ -187,19 +193,31 @@ export const Sidebar = ({
         <div className="flex items-center gap-3 px-3 py-2.5 rounded-2xl border border-transparent transition-all group/info">
         {/* 아바타/이미지 영역 */}
         <div 
+          key={currentUser.avatar}
           className="relative w-9 h-9 rounded-full shrink-0 cursor-pointer group/avatar overflow-hidden bg-slate-800 flex items-center justify-center"
           onClick={() => fileInputRef.current?.click()}
         >
-          {/* 이름 첫 글자 표시 */}
-          <span className="text-white font-bold text-xs uppercase">
-            {currentUser.name?.[0] || '?'}
-          </span>
+          {/* ✅ 1순위: currentUser.avatar (가져온 프로필 이미지)가 있으면 이미지 표시 */}
+  {currentUser?.avatar ? (
+  <img 
+    src={finalAvatar}
+    className="w-full h-full object-cover"
+    alt="프로필"
+    key={finalAvatar}
+  />
+) : (
+  <div className="w-full h-full bg-slate-200 flex items-center justify-center">
+    <span className="text-lg font-black text-slate-400">
+      {currentUser?.name?.[0] || 'U'}
+    </span>
+  </div>
+)}
 
-          {/* 마우스 호버 시 '수정 가능'임을 알리는 오버레이 */}
-          <div className="absolute inset-0 bg-black/60 flex items-center justify-center opacity-0 group-hover/avatar:opacity-100 transition-all duration-200">
-            <Pencil size={14} className="text-white" />
-          </div>
-        </div>
+  {/* 마우스 호버 시 오버레이 디자인 개선 */}
+  <div className="absolute inset-0 bg-black/60 flex flex-col items-center justify-center opacity-0 group-hover/avatar:opacity-100 transition-all duration-300 z-20 backdrop-blur-[1px]">
+    <Pencil size={16} className="text-white" />
+  </div>
+</div>
 
         {/* 이름 및 상태 정보 (클릭 시 상태 피커 열기) */}
         <div 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -198,26 +198,26 @@ const finalAvatar = myInfoFromTeam?.avatar || currentUser?.avatar;
           onClick={() => fileInputRef.current?.click()}
         >
           {/* ✅ 1순위: currentUser.avatar (가져온 프로필 이미지)가 있으면 이미지 표시 */}
-  {currentUser?.avatar ? (
-  <img 
-    src={finalAvatar}
-    className="w-full h-full object-cover"
-    alt="프로필"
-    key={finalAvatar}
-  />
-) : (
-  <div className="w-full h-full bg-slate-200 flex items-center justify-center">
-    <span className="text-lg font-black text-slate-400">
-      {currentUser?.name?.[0] || 'U'}
-    </span>
-  </div>
-)}
+          {currentUser?.avatar ? (
+          <img 
+            src={finalAvatar}
+            className="w-full h-full object-cover"
+            alt="프로필"
+            key={finalAvatar}
+          />
+        ) : (
+          <div className="w-full h-full bg-slate-200 flex items-center justify-center">
+            <span className="text-lg font-black text-slate-400">
+              {currentUser?.name?.[0] || 'U'}
+            </span>
+          </div>
+        )}
 
-  {/* 마우스 호버 시 오버레이 디자인 개선 */}
-  <div className="absolute inset-0 bg-black/60 flex flex-col items-center justify-center opacity-0 group-hover/avatar:opacity-100 transition-all duration-300 z-20 backdrop-blur-[1px]">
-    <Pencil size={16} className="text-white" />
-  </div>
-</div>
+          {/* 마우스 호버 시 오버레이 디자인 개선 */}
+          <div className="absolute inset-0 bg-black/60 flex flex-col items-center justify-center opacity-0 group-hover/avatar:opacity-100 transition-all duration-300 z-20 backdrop-blur-[1px]">
+            <Pencil size={16} className="text-white" />
+          </div>
+        </div>
 
         {/* 이름 및 상태 정보 (클릭 시 상태 피커 열기) */}
         <div 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -239,18 +239,13 @@ const finalAvatar = myInfoFromTeam?.avatar || currentUser?.avatar;
         {isStatusPickerOpen && (
           <StatusPicker 
             currentStatusLabel={myStatus.label}
-            onStatusChange={async (act) => {
-              console.log(`[Step 1] 상태 변경 클릭됨: ${act.label}`);
-              
+            onStatusChange={async (act) => {              
               try {
                 // 서버 API 호출 및 Pusher 방송 유도
-                console.log(`[Step 2] 서버에 상태 업데이트 요청 중...`);
                 await updateMyStatus(act.label); 
                 
                 // UI 닫기
                 setIsStatusPickerOpen(false);
-                
-                console.log(`[Step 3] 상태 변경 프로세스 완료! (Pusher 방송 대기 중)`);
               } catch (error) {
                 console.error(`[Error] 상태 변경 중 오류 발생:`, error);
                 alert("상태를 변경하지 못했습니다. 다시 시도해주세요.");

--- a/src/components/task/TicketDetail.tsx
+++ b/src/components/task/TicketDetail.tsx
@@ -233,11 +233,25 @@ export const TicketDetail = ({ ticket, currentUser, onClose, addComment, handleD
                   className={`flex gap-3 group relative ${isMe ? 'flex-row-reverse' : 'flex-row'}`}
                   onMouseLeave={() => setActiveMenuId(null)}
                 >
-                  {/* 아바타 */}
-                  <div className={`w-8 h-8 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0 ${
-                    isMe ? 'bg-blue-600 shadow-md' : 'bg-slate-200'
-                  }`}>
-                    {c.user ? c.user[0] : '?'}
+                  {/* 아바타 영역: 이미지 우선 노출 */}
+                  <div className={`w-8 h-8 rounded-full overflow-hidden relative shrink-0 flex items-center justify-center ${isMe ? 'bg-blue-600' : 'bg-slate-200'}`}>
+                    
+                    {/* 작성자 이미지가 존재할 때 출력 */}
+                    {c.userImage ? (
+                      <img 
+                        src={c.userImage} 
+                        alt={c.user} 
+                        className="w-full h-full object-cover relative z-10"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.display = 'none';
+                        }}
+                      />
+                    ) : null}
+
+                    {/* 이미지가 없거나 로드 실패 시 이름 첫 글자 (기존 로직) */}
+                    <span className="text-white font-bold text-[10px] absolute z-0">
+                      {c.user ? c.user[0] : '?'}
+                    </span>
                   </div>
 
                   {/* 말풍선 컨테이너 */}

--- a/src/components/task/TicketDetail.tsx
+++ b/src/components/task/TicketDetail.tsx
@@ -15,7 +15,7 @@ interface TicketDetailProps {
   onUpdateTicket: (taskId: number, data: { title: string; content: string; worker_id: string }) => Promise<void>;
 }
 
-export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComment, handleDeleteTicketApi, onUpdateComment, onDeleteComment, onUpdateTicket }: TicketDetailProps) => {
+export const TicketDetail = ({ ticket, currentUser, onClose, addComment, handleDeleteTicketApi, onUpdateComment, onDeleteComment, onUpdateTicket }: TicketDetailProps) => {
 
   // 권한 체크
   const isWorker = String(currentUser?.uuid) === String(ticket.worker_id);
@@ -190,22 +190,7 @@ export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComm
                 <p className="text-[9px] font-black text-slate-300 uppercase tracking-widest mb-1">
                   WORKER
                 </p>
-                {/* 수정 모드일 때 담당자 선택 Select 박스 노출 */}
-                {isEditingTask ? (
-                  <select
-                    value={taskForm.worker_id}
-                    onChange={(e) => setTaskForm({ ...taskForm, worker_id: e.target.value })}
-                    className="font-black text-blue-600 bg-blue-50 px-2 py-1 rounded-lg outline-none cursor-pointer"
-                  >
-                    {activeTeam.members.map((m) => (
-                      <option key={m.uuid} value={m.uuid}>
-                        {m.name}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <p className="font-black text-blue-600">{ticket.worker}</p>
-                )}
+                <p className="font-black text-blue-600">{ticket.worker}</p>
               </div>
               {/* 요청 취소(삭제) 버튼 */}
               {/* 담당자일 때만 버튼 활성화, 아닐 때는 비활성화 스타일 적용 */}
@@ -241,7 +226,6 @@ export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComm
               const isMe = c.user === currentUser.name;
               const isEditing = editingCommentId === c.id;
               const isMenuOpen = activeMenuId === c.id;
-              console.log(`${c.id}번 댓글 수정 여부:`, c.is_edited);
 
               return (
                 <div 
@@ -257,10 +241,9 @@ export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComm
                   </div>
 
                   {/* 말풍선 컨테이너 */}
-                  <div className={`relative max-w-[75%] group/bubble`}>
+                  <div className={`relative max-w-[75%] group/bubble flex items-end gap-2 ${isMe ? 'flex-row-reverse' : 'flex-row'}`}>
                     {isEditing ? (
-                      /* 수정 시, 입력창으로 전환 */
-                      <div className="flex flex-col gap-2">
+                      <div className="flex flex-col gap-2 w-full">
                         <textarea
                           value={editValue}
                           onChange={(e) => setEditValue(e.target.value)}
@@ -268,57 +251,46 @@ export const TicketDetail = ({ ticket, activeTeam, currentUser, onClose, addComm
                           autoFocus
                         />
                         <div className="flex justify-end gap-2">
-                          <button 
-                            onClick={() => setEditingCommentId(null)}
-                            className="text-[10px] font-bold text-slate-400"
-                          >
-                            취소
-                          </button>
-                          <button 
-                            onClick={() => handleUpdate(c.id)}
-                            className="text-[10px] font-bold text-blue-600"
-                          >
-                            저장
-                          </button>
+                          <button onClick={() => setEditingCommentId(null)} className="text-[10px] font-bold text-slate-400">취소</button>
+                          <button onClick={() => handleUpdate(c.id)} className="text-[10px] font-bold text-blue-600">저장</button>
                         </div>
                       </div>
                     ) : (
-                      /* 댓글 말풍선 출력 */
-                      <div className={`p-4 rounded-2xl text-xs leading-relaxed ${
-                        isMe 
-                          ? 'bg-blue-600 text-white rounded-tr-none shadow-sm'
-                          : 'bg-slate-50 text-slate-600 rounded-tl-none border border-slate-100'
-                      }`}>
-                        {!isMe && <p className="text-[9px] font-black mb-1 opacity-60">{c.user}</p>}
-                        
-                        <div className="flex flex-wrap items-end gap-2">
+                      <>
+                        {/* 댓글 말풍선 */}
+                        <div className={`p-4 rounded-2xl text-xs leading-relaxed ${
+                          isMe 
+                            ? 'bg-blue-600 text-white rounded-tr-none shadow-sm'
+                            : 'bg-slate-50 text-slate-600 rounded-tl-none border border-slate-100'
+                        }`}>
+                          {!isMe && <p className="text-[9px] font-black mb-1 opacity-60">{c.user}</p>}
                           <span>{c.text}</span>
-                          
-                          {/* 댓글 [수정됨] 표시 추가 */}
-                          {c.is_edited && (
-                            <span className="text-[8px] font-bold text-slate-400 opacity-60">
-                              (수정됨)
-                            </span>
-                          )}
                         </div>
-                      </div>
+
+                        {/* 표시를 말풍선 바깥쪽으로 이동 */}
+                        {c.is_edited && (
+                          <span className="text-[8px] font-bold text-slate-400 opacity-60 shrink-0 mb-1">
+                            (수정됨)
+                          </span>
+                        )}
+                      </>
                     )}
 
-                    {/* [더보기 버튼] 호버 시 노출 & 내 글일 때만 */}
+                    {/* [더보기 버튼] 내 글일 때만 노출 */}
                     {isMe && !isEditing && (
-                      <div className={`absolute top-1/2 -translate-y-1/2 ${isMe ? '-left-8' : '-right-8'} opacity-0 group-hover/bubble:opacity-100 transition-opacity`}>
+                      <div className="shrink-0 flex items-center mb-2">
                         <button 
                           onClick={() => setActiveMenuId(isMenuOpen ? null : c.id)}
-                          className="p-1 text-slate-400 hover:text-slate-600"
+                          className="p-1 text-slate-300 hover:text-slate-600 transition-colors"
                         >
                           <MoreHorizontal size={16} />
                         </button>
                       </div>
                     )}
 
-                    {/* 더보기 클릭 시 팝업 메뉴] */}
+                    {/* 더보기 클릭 시 팝업 메뉴 (기존 로직 유지) */}
                     {isMenuOpen && (
-                      <div className={`absolute z-10 top-6 ${isMe ? 'left-0' : 'right-0'} bg-white border border-slate-100 shadow-xl rounded-xl overflow-hidden py-1 min-w-20`}>
+                      <div className={`absolute z-10 top-full mt-1 ${isMe ? 'right-0' : 'left-0'} bg-white border border-slate-100 shadow-xl rounded-xl overflow-hidden py-1 min-w-20`}>
                         <button 
                           onClick={() => startEdit(c.id, c.text)}
                           className="w-full px-3 py-2 text-[10px] font-bold text-slate-600 hover:bg-slate-50 flex items-center gap-2"

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -10,17 +10,12 @@ import { useEffect, useMemo } from 'react';
 import { pusher } from '../utils/pusher';
 import type { NotificationItem, PusherNotificationData } from '../types';
 
-// // 알림 타입별 태그 매핑
-// const getNotificationTag = (type: string): string => {
-//   switch (type) {
-//     case 'NEW_TASK': return '[신규]';
-//     case 'NEW_COMMENT': return '[댓글]';
-//     case 'TASK_UPDATED': return '[수정]';
-//     case 'STATUS_CHANGED': return '[상태]';
-//     case 'TASK_DELETED': return '[삭제]';
-//     default: return '[알림]';
-//   }
-// };
+interface ExtendedNotificationItem extends NotificationItem {
+  team_name?: string;
+  team?: {
+    name: string;
+  };
+}
 
 export const useNotifications = (currentUserUuid: string | undefined) => {
   const queryClient = useQueryClient();
@@ -80,17 +75,23 @@ export const useNotifications = (currentUserUuid: string | undefined) => {
 
   // 데이터 가공
   const processedNotifications = useMemo((): (NotificationItem & { isNew: boolean })[] => {
-    const allList: NotificationItem[] = Array.isArray(allResponse?.data) 
+  const allList: ExtendedNotificationItem[] = Array.isArray(allResponse?.data) 
     ? allResponse.data 
     : [];
-    const unreadList: NotificationItem[] = unreadResponse?.data?.notifications || [];
-    const unreadIds = new Set(unreadList.map(n => n.id));
+    
+  const unreadList: NotificationItem[] = unreadResponse?.data?.notifications || [];
+  const unreadIds = new Set(unreadList.map(n => n.id));
 
-    return allList.map(noti => ({
+  return allList.map(noti => {
+    const teamNameValue = noti.teamName || noti.team_name || noti.team?.name || '알 수 없는 팀';
+
+    return {
       ...noti,
+      teamName: teamNameValue,
       isNew: unreadIds.has(noti.id) || !noti.is_read
-    }));
-  }, [allResponse, unreadResponse]);
+    };
+  });
+}, [allResponse, unreadResponse]);
 
   const readMutation = useMutation({
     mutationFn: (id: number) => readNotificationApi(id),

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -10,17 +10,17 @@ import { useEffect, useMemo } from 'react';
 import { pusher } from '../utils/pusher';
 import type { NotificationItem, PusherNotificationData } from '../types';
 
-// 알림 타입별 태그 매핑
-const getNotificationTag = (type: string): string => {
-  switch (type) {
-    case 'NEW_TASK': return '[신규]';
-    case 'NEW_COMMENT': return '[댓글]';
-    case 'TASK_UPDATED': return '[수정]';
-    case 'STATUS_CHANGED': return '[상태]';
-    case 'TASK_DELETED': return '[삭제]';
-    default: return '[알림]';
-  }
-};
+// // 알림 타입별 태그 매핑
+// const getNotificationTag = (type: string): string => {
+//   switch (type) {
+//     case 'NEW_TASK': return '[신규]';
+//     case 'NEW_COMMENT': return '[댓글]';
+//     case 'TASK_UPDATED': return '[수정]';
+//     case 'STATUS_CHANGED': return '[상태]';
+//     case 'TASK_DELETED': return '[삭제]';
+//     default: return '[알림]';
+//   }
+// };
 
 export const useNotifications = (currentUserUuid: string | undefined) => {
   const queryClient = useQueryClient();
@@ -46,8 +46,9 @@ export const useNotifications = (currentUserUuid: string | undefined) => {
     const userChannel = pusher.subscribe(`user-${currentUserUuid}`);
 
     userChannel.bind('new-notification', (data: PusherNotificationData) => {
-      const tag = getNotificationTag(data.type);
-      const fullMessage = `${tag} ${data.message}`;
+      console.log("🚀 Pusher 수신 데이터:", data);
+      const teamLabel = data.teamName ? `[${data.teamName}]` : '[알림]';
+      const fullMessage = `${teamLabel} ${data.message}`;
 
       toast.success(fullMessage, {
         duration: 4000,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -46,7 +46,6 @@ export const useNotifications = (currentUserUuid: string | undefined) => {
     const userChannel = pusher.subscribe(`user-${currentUserUuid}`);
 
     userChannel.bind('new-notification', (data: PusherNotificationData) => {
-      console.log("🚀 Pusher 수신 데이터:", data);
       const teamLabel = data.teamName ? `[${data.teamName}]` : '[알림]';
       const fullMessage = `${teamLabel} ${data.message}`;
 

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -205,7 +205,6 @@ export const useTeams = (
   const { data: onlineUsersData } = useQuery<GetOnlineUsersResponse>({
     queryKey: ['onlineUsers', activeTeamId],
     queryFn: () => {
-      console.log('🚀 온라인 유저 API 호출 시도! 팀 ID:', activeTeamId);
       return getOnlineUsersApi(Number(activeTeamId));
     },
     enabled: !!activeTeamId && activeTeamId !== '0',
@@ -370,7 +369,6 @@ export const useTeams = (
     // 특정 테스크 모달이 열려 있을 때만 리스너를 가동합니다.
     if (!selectedTicketId) return;
 
-    console.log(`[Pusher] #${selectedTicketId} 테스크 채널 구독 시도...`);
     const taskChannel = pusher.subscribe(`task-${selectedTicketId}`);
 
     taskChannel.bind('new-comment', () => {
@@ -777,7 +775,6 @@ export const useTeams = (
         await queryClient.invalidateQueries({
           queryKey: ['logs', activeTeamId],
         });
-        console.log('✅ 티켓 생성 성공 및 데이터 동기화 완료');
       }
     } catch (error: unknown) {
       console.error('❌ 티켓 생성 중 오류 발생:', error);
@@ -791,16 +788,10 @@ export const useTeams = (
   const handleAddComment = async (ticketId: number, text: string) => {
     if (!text || !currentUser || !activeTeamId) return false;
 
-    console.log(
-      `🚀 [댓글전송] ${ticketId}번 테스크에 댓글 작성 시도: "${text}"`,
-    );
-
     try {
       const response = await createCommentApi(ticketId, text);
 
       if (response.success) {
-        console.log('✅ [서버응답] 댓글 저장 완료. 데이터를 새로고침합니다.');
-
         await Promise.all([
           queryClient.invalidateQueries({
             queryKey: ['ticketDetail', ticketId],

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -13,7 +13,6 @@ import type {
   CurrentUser,
   TeamFromApi,
   TeamArchiveData,
-  PusherCommentData,
   TaskBaseFromApi,
   TaskComment,
   TaskCommentFromApi,
@@ -374,9 +373,7 @@ export const useTeams = (
     console.log(`[Pusher] #${selectedTicketId} 테스크 채널 구독 시도...`);
     const taskChannel = pusher.subscribe(`task-${selectedTicketId}`);
 
-    taskChannel.bind('new-comment', (data: PusherCommentData) => {
-      console.log('💬 [Pusher] 실시간 댓글 이벤트 발생!', data);
-      // 💡 여기서 invalidateQueries를 호출해야 위 useMemo가 다시 작동합니다.
+    taskChannel.bind('new-comment', () => {
       queryClient.invalidateQueries({
         queryKey: ['ticketDetail', selectedTicketId],
       });
@@ -445,9 +442,12 @@ export const useTeams = (
           if (isSelected && currentDetail && 'comments' in currentDetail) {
             serverComments = currentDetail.comments.map(
               (c: TaskCommentFromApi): TaskComment => {
+                const writer = baseTeam.members.find((m) => m.name === c.user.name);
                 return {
                   id: c.id,
                   user: c.user.name,
+                  // ✅ 2. 찾은 멤버의 avatar(사진)를 userImage 필드에 넣어줍니다.
+                  userImage: writer?.avatar || null, 
                   text: c.content,
                   time: new Date(c.created_at).toLocaleTimeString('ko-KR', {
                     hour12: false,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -78,7 +78,6 @@ export const Dashboard = ({
 
   // 실시간 감시용 = 티켓이 추가되면 로그 숫자가 변경되어야 함
   useEffect(() => {
-    console.log('현재 티켓 수:', activeTeam.tickets.length);
   }, [activeTeam.tickets]);
 
   const CreateTicketModal = (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export interface Member {
   uuid: string;
   name: string;
   position: string;
+  imgUrl?: string;
   avatar?: string;
   email: string;
   phone: string;
@@ -163,6 +164,7 @@ export interface NotificationItem {
   id: number;
   user_id: string;
   team_id: number;
+  teamName: string;
   task_id: number | null;
   type: NotificationType;
   message: string;
@@ -176,6 +178,7 @@ export interface PusherNotificationData {
   message: string;
   taskId: number;
   teamId: number;
+  teamName: string;
 }
 
 // 팀 아카이브: 공유 링크, 문서, 회의록 공통 데이터

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,35 @@ export interface UserInfoResponse {
   avatar?: string;
 }
 
+// 서버에서 보내주는 유저 데이터의 원본 규격
+export interface UserRawData {
+  id?: number;
+  uuid: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  position?: string;
+  github?: string;
+  profileImage?: string;
+}
+
+// getMyInfoApi의 전체 응답 타입
+export interface GetMyInfoResponse {
+  success: boolean;
+  data: {
+    id: number;
+    uuid: string;
+    name: string;
+    email: string;
+    profileImage: string; // ✅ 이 부분이 있어야 합니다.
+    phone?: string;
+    position?: string;
+    github?: string;
+  } | null;
+  meta: null;
+  error: string | null;
+}
+
 // 활동 중인 유저 정보 : 서버 응답
 export interface OnlineUserFromApi {
   id: number;
@@ -103,6 +132,7 @@ export interface TaskDetailFromApi extends TaskBaseFromApi {
 export interface TaskComment {
   id: number;
   user: string;
+  userImage?: string | null;
   text: string;
   time: string;
   is_edited: boolean;

--- a/src/utils/pusher.ts
+++ b/src/utils/pusher.ts
@@ -1,10 +1,5 @@
 import Pusher from 'pusher-js';
 
-// Pusher 로그 디버깅 (개발 중에 연결 상태를 콘솔에서 보고 싶을 때 사용)
-if (import.meta.env.DEV) {
-  Pusher.logToConsole = true;
-}
-
 export const pusher = new Pusher(import.meta.env.VITE_PUSHER_KEY, {
   cluster: import.meta.env.VITE_PUSHER_CLUSTER,
   forceTLS: true, // 보안 연결(HTTPS)


### PR DESCRIPTION
- [x] 댓글 수정/삭제 더보기 버튼을 호버시 뜨는 거 말고, 고정으로 + [수정됨]도 말풍선 밖으로 수정
<img width="1710" height="950" alt="Image" src="https://github.com/user-attachments/assets/abb35c0c-4db2-4f94-9f5c-5a681d18214c" />

- [x] task 수정 시, 담당자 변경 불가하도록 수정
<img width="3420" height="1900" alt="Image" src="https://github.com/user-attachments/assets/72315a39-25d7-4e63-90bc-15f5a095a734" />

- [x] 다른팀으로 이동해도 다른 팀 알림이 뜨는 상황 -> 어느 팀 알림인지 알 수 있도록 수정
<img width="1710" height="950" alt="Image" src="https://github.com/user-attachments/assets/55188480-c884-45be-8c64-5cea546435e4" />

- [x] 토스트 알림에도 팀 name 추가
<img width="3420" height="1900" alt="Image" src="https://github.com/user-attachments/assets/1b5eaced-ffbb-4db2-a943-b028ddd7ee2f" />

- [x] 사이드바 하단에 있는 내 프로필에서 프로필 이미지 뜨도록 수정 
<img width="3420" height="1900" alt="Image" src="https://github.com/user-attachments/assets/e32e6dc8-261f-48b9-b00e-e23a5ed6bb96" />

- [x] 댓글에도 프로필 이미지 적용
<img width="1710" height="950" alt="Image" src="https://github.com/user-attachments/assets/659c1329-4f79-4e02-965b-8e339923bae7" />