### PR TITLE
[jh_bug/#105] 댓글 팝업 + 알림 클릭 이벤트 + 사이드바 이미지 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -855,6 +855,8 @@ export default function App() {
               setIsCreateModalOpen={() => setActiveModal('create')}
               currentUser={currentUser}
               setSelectedTicketId={setSelectedTicketId}
+              setActiveTeamId={setActiveTeamId}
+              setView={setView}
             />
             <div className="flex-1 overflow-y-auto p-6 bg-slate-50">
               {view === 'dashboard' && activeTeam && (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,14 +19,19 @@ interface HeaderProps {
   setIsCreateModalOpen: (open: boolean) => void;
   currentUser: CurrentUser;
   setSelectedTicketId: (id: number | null) => void;
+  setActiveTeamId: (id: string | null) => void; 
+  setView: (view: 'dashboard' | 'members' | 'archive') => void;
 }
 
 export const Header = ({
   view,
+  activeTeam,
   onlineUsers,
   setIsCreateModalOpen,
   currentUser,
-  setSelectedTicketId
+  setSelectedTicketId,
+  setActiveTeamId,
+  setView
 }: HeaderProps) => {
   const { 
     notifications,
@@ -138,7 +143,20 @@ export const Header = ({
                       onClick={() => {
                         // 특정 알림 클릭 시 읽음 처리 API 호출
                         readNotification(noti.id);
-                        if (noti.task_id) setSelectedTicketId(noti.task_id);
+                        const targetTeamId = String(noti.team_id);
+                        const currentTeamId = String(activeTeam?.id);
+
+                        if (targetTeamId !== currentTeamId) {
+                          if (window.confirm(`'${noti.teamName}' 팀으로 이동하시겠습니까?`)) {
+
+                            setActiveTeamId(targetTeamId);
+                            setView('dashboard');
+                            
+                            if (noti.task_id) setSelectedTicketId(noti.task_id);
+                          }
+                        } else {
+                          if (noti.task_id) setSelectedTicketId(noti.task_id);
+                        }
                         setIsNotiOpen(false);
                       }}
                       className={`p-4 border-b border-slate-50 cursor-pointer transition-all relative flex gap-3 ${

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -197,23 +197,38 @@ const finalAvatar = myInfoFromTeam?.avatar || currentUser?.avatar;
           className="relative w-9 h-9 rounded-full shrink-0 cursor-pointer group/avatar overflow-hidden bg-slate-800 flex items-center justify-center"
           onClick={() => fileInputRef.current?.click()}
         >
-          {/* ✅ 1순위: currentUser.avatar (가져온 프로필 이미지)가 있으면 이미지 표시 */}
-          {currentUser?.avatar ? (
-          <img 
-            src={finalAvatar}
-            className="w-full h-full object-cover"
-            alt="프로필"
-            key={finalAvatar}
-          />
-        ) : (
-          <div className="w-full h-full bg-slate-200 flex items-center justify-center">
-            <span className="text-lg font-black text-slate-400">
-              {currentUser?.name?.[0] || 'U'}
-            </span>
-          </div>
-        )}
+          {/* 이미지 유효성 체크 로직 */}
+          {finalAvatar && (finalAvatar.startsWith('http') || finalAvatar.startsWith('/') || finalAvatar.startsWith('data:')) ? (
+            <img 
+              src={finalAvatar}
+              className="w-full h-full object-cover"
+              alt="프로필"
+              onError={(e) => {
+                // 이미지 로드 실패 시 텍스트로 대체하기 위해 에러 처리
+                (e.target as HTMLImageElement).style.display = 'none';
+                (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden');
+              }}
+            />
+          ) : null}
 
-          {/* 마우스 호버 시 오버레이 디자인 개선 */}
+          {/* 이미지가 없거나, 위 조건(경로)이 아니면 이모지/첫글자 출력 */}
+          {(!finalAvatar || !(finalAvatar.startsWith('http') || finalAvatar.startsWith('/') || finalAvatar.startsWith('data:'))) ? (
+            <div className="w-full h-full bg-slate-200 flex items-center justify-center">
+              <span className="text-lg font-black text-slate-500">
+                {/* 이모지라면 그대로 출력, 이름이라면 첫 글자 출력 */}
+                {finalAvatar || currentUser?.name?.[0] || 'U'}
+              </span>
+            </div>
+          ) : (
+            // 이미지 로드 실패 시 나타날 백업 UI 
+            <div className="hidden absolute inset-0 w-full h-full bg-slate-200 items-center justify-center">
+              <span className="text-lg font-black text-slate-500">
+                {currentUser?.name?.[0] || 'U'}
+              </span>
+            </div>
+          )}
+
+          {/* 마우스 호버 시 오버레이 */}
           <div className="absolute inset-0 bg-black/60 flex flex-col items-center justify-center opacity-0 group-hover/avatar:opacity-100 transition-all duration-300 z-20 backdrop-blur-[1px]">
             <Pencil size={16} className="text-white" />
           </div>

--- a/src/components/task/TicketDetail.tsx
+++ b/src/components/task/TicketDetail.tsx
@@ -91,6 +91,25 @@ export const TicketDetail = ({ ticket, currentUser, onClose, addComment, handleD
       console.error("삭제 중 에러:", error);
     }
   };
+
+  // 댓글 팝업 바깥 클릭 감지를 위한 Ref
+  const commentMenuRef = useRef<HTMLDivElement>(null);
+
+  // ✅ 댓글 메뉴 바깥 클릭 시 닫기 로직
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      // 클릭된 타겟이 메뉴 영역(commentMenuRef) 외부에 있다면 닫기
+      if (commentMenuRef.current && !commentMenuRef.current.contains(e.target as Node)) {
+        setActiveMenuId(null);
+      }
+    };
+
+    if (activeMenuId !== null) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [activeMenuId]);
   
   return (
     // 고정된 전체 화면 오버레이 (Backdrop)
@@ -231,7 +250,7 @@ export const TicketDetail = ({ ticket, currentUser, onClose, addComment, handleD
                 <div 
                   key={c.id} 
                   className={`flex gap-3 group relative ${isMe ? 'flex-row-reverse' : 'flex-row'}`}
-                  onMouseLeave={() => setActiveMenuId(null)}
+                  // onMouseLeave={() => setActiveMenuId(null)}
                 >
                   {/* 아바타 영역: 이미지 우선 노출 */}
                   <div className={`w-8 h-8 rounded-full overflow-hidden relative shrink-0 flex items-center justify-center ${isMe ? 'bg-blue-600' : 'bg-slate-200'}`}>
@@ -282,49 +301,58 @@ export const TicketDetail = ({ ticket, currentUser, onClose, addComment, handleD
                         </div>
 
                         {/* 표시를 말풍선 바깥쪽으로 이동 */}
+                        <div className={`flex items-center gap-1.5 mb-1 shrink-0 relative ${isMe ? 'flex-row-reverse' : 'flex-row'}`}>
                         {c.is_edited && (
-                          <span className="text-[8px] font-bold text-slate-400 opacity-60 shrink-0 mb-1">
+                          <span className="text-[8px] font-bold text-slate-400 opacity-60">
                             (수정됨)
                           </span>
                         )}
-                      </>
-                    )}
-
-                    {/* [더보기 버튼] 내 글일 때만 노출 */}
-                    {isMe && !isEditing && (
-                      <div className="shrink-0 flex items-center mb-2">
-                        <button 
-                          onClick={() => setActiveMenuId(isMenuOpen ? null : c.id)}
-                          className="p-1 text-slate-300 hover:text-slate-600 transition-colors"
-                        >
-                          <MoreHorizontal size={16} />
-                        </button>
-                      </div>
-                    )}
-
-                    {/* 더보기 클릭 시 팝업 메뉴 (기존 로직 유지) */}
-                    {isMenuOpen && (
-                      <div className={`absolute z-10 top-full mt-1 ${isMe ? 'right-0' : 'left-0'} bg-white border border-slate-100 shadow-xl rounded-xl overflow-hidden py-1 min-w-20`}>
-                        <button 
-                          onClick={() => startEdit(c.id, c.text)}
-                          className="w-full px-3 py-2 text-[10px] font-bold text-slate-600 hover:bg-slate-50 flex items-center gap-2"
-                        >
-                          <Pencil size={12} /> 수정
-                        </button>
-                        <button 
-                          onClick={() => handleDelete(c.id)}
-                          className="w-full px-3 py-2 text-[10px] font-bold text-red-500 hover:bg-red-50 flex items-center gap-2"
-                        >
-                          <Trash2 size={12} /> 삭제
-                        </button>
+                      
+                        {/* [더보기 버튼] 내 글일 때만 노출 */}
+                        {isMe && !isEditing && (
+                          <div 
+                            className="relative" 
+                            // ✅ 현재 이 댓글의 메뉴가 열려있을 때만 Ref를 연결하여 감지 대상으로 지정
+                            ref={isMenuOpen ? commentMenuRef : null}
+                          >
+                            <button 
+                              onClick={(e) => {
+                                e.stopPropagation(); 
+                                setActiveMenuId(isMenuOpen ? null : c.id);
+                              }}
+                              className="p-1 text-slate-300 hover:text-slate-600 transition-all rounded-full hover:bg-slate-50"
+                            >
+                              <MoreHorizontal size={16} />
+                            </button>
+                      
+                        {/* ✅ 더보기 버튼 바로 아래에 고정되도록 이동 */}
+                        {isMenuOpen && (
+                          <div className={`absolute z-10 top-full mt-2 ${isMe ? 'right-0' : 'left-0'} bg-white border border-slate-100 shadow-xl rounded-xl overflow-hidden py-1 min-w-24`}>
+                            <button 
+                              onClick={() => startEdit(c.id, c.text)}
+                              className="w-full px-3 py-2 text-[10px] font-bold text-slate-600 hover:bg-slate-50 flex items-center gap-2"
+                            >
+                              <Pencil size={12} /> 수정
+                            </button>
+                            <button 
+                              onClick={() => handleDelete(c.id)}
+                              className="w-full px-3 py-2 text-[10px] font-bold text-red-500 hover:bg-red-50 flex items-center gap-2"
+                            >
+                              <Trash2 size={12} /> 삭제
+                            </button>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>
-                </div>
-              );
-            })}
-            <div ref={messagesEndRef} />
-        </div>
+                </>
+              )}
+            </div>
+          </div>
+        );
+      })}
+      <div ref={messagesEndRef} />
+    </div>
 
         {/* 푸터 섹션: 댓글 입력 폼 */}
         <div className="px-8 py-6 border-t border-slate-100 bg-white shrink-0">


### PR DESCRIPTION
댓글
- [x] 댓글 팝업 클릭 후 유지
- [x] 댓글 팝업 위치 수정 
<img width="3420" height="1902" alt="image" src="https://github.com/user-attachments/assets/6f596f29-ffe9-49bc-bf7a-0252a1da1f3e" />

---

알림
- [x] 다른 팀에서 온 알림 클릭 시, 해당 팀으로 이동하는 방식으로 수정
<img width="3420" height="1926" alt="2 19000" src="https://github.com/user-attachments/assets/f975b25d-9022-454a-a5f6-e741c5e41415" />
<img width="3420" height="1902" alt="image" src="https://github.com/user-attachments/assets/8190d7e1-058b-4dad-a223-f05244c27faf" />

---

사이드바
- [x] 사이드바 이미지 없을때 깨진 이미지 출력 문제 수정
<img width="3420" height="1900" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/4cedcc99-a185-4f35-bfa9-ae3ebb4c4678" />
