### PR TITLE
Sh feat/#106 : 회의록 동시 수정, 삭제 시 충돌 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import {
 import { createDocApi, createQuickLinkApi } from './api/archive';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Toaster } from "react-hot-toast";
+import { Toaster } from 'react-hot-toast';
 
 // 레이아웃 및 페이지
 import { Sidebar } from './components/layout/Sidebar';
@@ -32,7 +32,7 @@ import { Modal } from './components/ui/Modal';
 import { useTeams } from './hooks/useTeams';
 import { type Member, type CurrentUser, type TeamArchiveData } from './types';
 import { validateUrl } from './utils/validation';
-import { updateMyStatusApi } from "./api/status";
+import { updateMyStatusApi } from './api/status';
 
 export default function App() {
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
@@ -66,7 +66,8 @@ export default function App() {
     leaveTeam,
     editNote,
     deleteNote,
-    updateProfileImage
+    updateProfileImage,
+    startEditingNote,
   } = useTeams(currentUser, selectedTicketId, setSelectedTicketId);
 
   // --- UI 상태 관리 ---
@@ -172,15 +173,20 @@ export default function App() {
   const logoutMutation = useMutation({ mutationFn: logoutApi });
 
   // 공통 상태 업데이트 헬퍼 함수
-  const syncUserStatus = useCallback(async (teamId: number, status: string) => {
-    try {
-      await updateMyStatusApi(teamId, status);
-      queryClient.invalidateQueries({ queryKey: ['teams'] });
-      queryClient.invalidateQueries({ queryKey: ['onlineUsers', String(teamId)] });
-    } catch (err) {
-      console.warn(`[Status Sync] ${status} 업데이트 실패:`, err);
-    }
-  }, [queryClient]);
+  const syncUserStatus = useCallback(
+    async (teamId: number, status: string) => {
+      try {
+        await updateMyStatusApi(teamId, status);
+        queryClient.invalidateQueries({ queryKey: ['teams'] });
+        queryClient.invalidateQueries({
+          queryKey: ['onlineUsers', String(teamId)],
+        });
+      } catch (err) {
+        console.warn(`[Status Sync] ${status} 업데이트 실패:`, err);
+      }
+    },
+    [queryClient],
+  );
 
   // 팀 생성 API 호출
   const createTeamMutation = useMutation({
@@ -239,64 +245,65 @@ export default function App() {
   });
 
   // 세션 복원 로직
-  const { data: userData, isLoading: isUserLoading } = useQuery<GetMyInfoResponse>({
-    queryKey: ['myInfo'],
-    queryFn: getMyInfoApi,
-    staleTime: Infinity,
-    gcTime: Infinity,
-    retry: false,
-  });
+  const { data: userData, isLoading: isUserLoading } =
+    useQuery<GetMyInfoResponse>({
+      queryKey: ['myInfo'],
+      queryFn: getMyInfoApi,
+      staleTime: Infinity,
+      gcTime: Infinity,
+      retry: false,
+    });
 
   useEffect(() => {
-  // 데이터가 없거나 실패면 중단
-  if (!userData?.success || !userData.data) {
-    if (!isUserLoading) setIsAuthLoading(false);
-    return;
-  }
-
-  const userRawData = userData.data;
-
-  // 이름 복구 로직
-  const savedDisplayName = localStorage.getItem('displayName');
-  const restoredName = 
-    userRawData.name || 
-    savedDisplayName || 
-    userRawData.email?.split('@')[0] || 
-    '사용자';
-
-  setCurrentUser({
-    ...userRawData,
-    id: userRawData.id,
-    uuid: userRawData.uuid,
-    name: restoredName,
-    avatar: userRawData.profileImage || '', 
-    email: userRawData.email || '',
-    phone: userRawData.phone || '',
-    position: userRawData.position || '팀원',
-    github: userRawData.github || '',
-  });
-
-  if (userRawData.name) {
-    localStorage.setItem('displayName', userRawData.name);
-  }
-
-  import('./utils/pusher').then(({ pusher }) => pusher.connect());
-
-  const lastTeamId = localStorage.getItem('lastTeamId');
-  const wasAuthorized = localStorage.getItem('isTeamAuthorized') === 'true';
-
-  if (lastTeamId) {
-    syncUserStatus(Number(lastTeamId), '업무 중');
-    if (wasAuthorized) {
-      setActiveTeamId(lastTeamId);
-      setIsTeamAuthorized(true);
+    // 데이터가 없거나 실패면 중단
+    if (!userData?.success || !userData.data) {
+      if (!isUserLoading) setIsAuthLoading(false);
+      return;
     }
-  }
 
-  if (!isUserLoading) {
-    setIsAuthLoading(false);
-  }
-}, [userData, isUserLoading, setActiveTeamId, queryClient, syncUserStatus]);
+    const userRawData = userData.data;
+
+    // 이름 복구 로직
+    const savedDisplayName = localStorage.getItem('displayName');
+    const restoredName =
+      userRawData.name ||
+      savedDisplayName ||
+      userRawData.email?.split('@')[0] ||
+      '사용자';
+
+    setCurrentUser({
+      ...userRawData,
+      id: userRawData.id,
+      uuid: userRawData.uuid,
+      name: restoredName,
+      avatar: userRawData.profileImage || '',
+      email: userRawData.email || '',
+      phone: userRawData.phone || '',
+      position: userRawData.position || '팀원',
+      github: userRawData.github || '',
+    });
+
+    if (userRawData.name) {
+      localStorage.setItem('displayName', userRawData.name);
+    }
+
+    import('./utils/pusher').then(({ pusher }) => pusher.connect());
+
+    const lastTeamId = localStorage.getItem('lastTeamId');
+    const wasAuthorized = localStorage.getItem('isTeamAuthorized') === 'true';
+
+    if (lastTeamId) {
+      syncUserStatus(Number(lastTeamId), '업무 중');
+      if (wasAuthorized) {
+        setActiveTeamId(lastTeamId);
+        setIsTeamAuthorized(true);
+      }
+    }
+
+    if (!isUserLoading) {
+      setIsAuthLoading(false);
+    }
+  }, [userData, isUserLoading, setActiveTeamId, queryClient, syncUserStatus]);
 
   // --- 세션 유지 로직 ---
   useEffect(() => {
@@ -518,10 +525,16 @@ export default function App() {
     setIsEditNotePending(true);
 
     try {
-      await editNote(selectedNote.id, noteData);
-      setSelectedNote({ ...selectedNote, ...noteData });
-      alert('회의록이 성공적으로 수정되었습니다.');
-      setActiveModal(null);
+      const result = await editNote(selectedNote.id, noteData);
+
+      if (result?.ok) {
+        setSelectedNote({ ...selectedNote, ...noteData });
+        alert('회의록이 성공적으로 수정되었습니다.');
+        setActiveModal(null);
+      } else if (result?.conflict) {
+        setActiveModal(null);
+        setSelectedNote(null);
+      }
     } catch (error) {
       console.log(error);
     } finally {
@@ -532,18 +545,22 @@ export default function App() {
   // 회의록 삭제
   const handleDeleteNote = async (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
 
     const noteId = selectedNote?.id;
     if (!noteId) return;
-    if (!window.confirm('정말 이 회의록을 삭제하시겠습니까?')) return;
 
     try {
-      await deleteNote(noteId);
-      alert('회의록이 성공적으로 삭제되었습니다.');
-      setSelectedNote(null);
+      const result = await deleteNote(noteId);
+
+      if (result?.ok) {
+        alert('회의록이 성공적으로 삭제되었습니다.');
+        setSelectedNote(null);
+      } else if (result?.conflict) {
+        setSelectedNote(null);
+      }
     } catch (error) {
       console.log(error);
-      alert('회의록 삭제에 실패했습니다.');
     }
   };
 
@@ -698,7 +715,6 @@ export default function App() {
       localStorage.setItem('currentView', 'dashboard');
 
       await leaveTeam(Number(teamId));
-
     } catch (error: unknown) {
       console.error('탈퇴 처리 중 오류:', error);
 
@@ -710,10 +726,7 @@ export default function App() {
       if (prevActiveTeamId) {
         localStorage.setItem('lastTeamId', String(prevActiveTeamId));
       }
-      localStorage.setItem(
-        'isTeamAuthorized',
-        String(prevIsTeamAuthorized),
-      );
+      localStorage.setItem('isTeamAuthorized', String(prevIsTeamAuthorized));
       localStorage.setItem('currentView', prevView);
 
       alert('팀 탈퇴 처리 중 문제가 발생했습니다.');
@@ -762,7 +775,10 @@ export default function App() {
         try {
           await syncUserStatus(Number(activeTeamId), '자리 비움');
         } catch (err) {
-          console.warn("로그아웃 상태 업데이트 실패 (무시하고 로그아웃 진행):", err);
+          console.warn(
+            '로그아웃 상태 업데이트 실패 (무시하고 로그아웃 진행):',
+            err,
+          );
         }
       }
 
@@ -771,7 +787,7 @@ export default function App() {
         alert(data.error || '로그아웃에 실패했습니다.');
         return;
       }
-      
+
       setCurrentUser(null);
       setActiveTeamId(null);
       setIsTeamAuthorized(false);
@@ -816,8 +832,8 @@ export default function App() {
 
   return (
     <>
-    {/* 토스트 알림 기능 */}
-    <Toaster 
+      {/* 토스트 알림 기능 */}
+      <Toaster
         position="top-right" // 알림 위치: 우측 상단
         reverseOrder={false}
         toastOptions={{
@@ -1326,7 +1342,10 @@ export default function App() {
               회의록 삭제
             </button>
             <button
-              onClick={() => handleOpenUpdateNoteModal(selectedNote)}
+              onClick={() => {
+                handleOpenUpdateNoteModal(selectedNote);
+                startEditingNote(selectedNote.id);
+              }}
               className="px-4 py-4 bg-blue-600 hover:bg-blue-700 text-white rounded-2xl font-bold cursor-pointer"
             >
               회의록 수정

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -550,14 +550,18 @@ export default function App() {
     const noteId = selectedNote?.id;
     if (!noteId) return;
 
+    if (!window.confirm('정말 이 회의록을 삭제하시겠습니까?')) return;
+
     try {
       const result = await deleteNote(noteId);
 
-      if (result?.ok) {
-        alert('회의록이 성공적으로 삭제되었습니다.');
+      if (result?.ok || result?.conflict) {
         setSelectedNote(null);
-      } else if (result?.conflict) {
-        setSelectedNote(null);
+
+        // 성공했을 때만 별도의 완료 메시지 노출 (충돌 시엔 훅에서 이미 알럿 띄움)
+        if (result?.ok) {
+          alert('회의록이 성공적으로 삭제되었습니다.');
+        }
       }
     } catch (error) {
       console.log(error);
@@ -756,10 +760,8 @@ export default function App() {
       alert(`내 포지션이 "${myPosition}" 성공적으로 변경되었습니다.`);
     } catch (error: unknown) {
       if (error instanceof Error) {
-        console.log('포지션 수정 API 호출 실패 :', error.message);
         alert(error.message || '포지션 수정에 실패했습니다.');
       } else {
-        console.log('알 수 없는 에러 발생 :', error);
         alert('포지션 수정에 실패했습니다.');
       }
     } finally {
@@ -1336,7 +1338,9 @@ export default function App() {
 
           <div className="flex justify-end gap-4">
             <button
-              onClick={(e) => handleDeleteNote(e)}
+              onClick={(e) => {
+                handleDeleteNote(e);
+              }}
               className="px-4 py-4 bg-white hover:bg-red-50 border border-red-200 text-red-500 rounded-2xl font-bold cursor-pointer"
             >
               회의록 삭제

--- a/src/api/archive.ts
+++ b/src/api/archive.ts
@@ -94,6 +94,7 @@ export const getNotesApi = async (teamId: number) => {
 export interface NoteRequest {
   title: string;
   content: string;
+  version?: number; // 회의록 버전 정보 (옵션)
 }
 
 export const createNoteApi = async (teamId: number, data: NoteRequest) => {
@@ -109,15 +110,21 @@ export const getNoteDetailApi = async (archiveId: number) => {
   return response.data;
 };
 
-export const editNoteApi = async (archiveId: number, data: NoteRequest) => {
+export const editNoteApi = async (
+  archiveId: number,
+  data: NoteRequest & { version: number },
+) => {
   const response = await api.patch(`/archives/${archiveId}/meeting`, {
     title: data.title,
     content: data.content,
+    version: data.version,
   });
   return response.data;
 };
 
-export const deleteNoteApi = async (archiveId: number) => {
-  const response = await api.delete(`/archives/${archiveId}/meeting`);
+export const deleteNoteApi = async (archiveId: number, version: number) => {
+  const response = await api.delete(`/archives/${archiveId}/meeting`, {
+    params: { version },
+  });
   return response.data;
 };

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -40,6 +40,7 @@ import {
   deleteQuickLinkApi,
   editNoteApi,
   getDocApi,
+  getNoteDetailApi,
   getNotesApi,
   getQuickLinksApi,
   type NoteRequest,
@@ -98,17 +99,17 @@ const convertTeam = (team: TeamFromApi): Team => {
   const mappedMembers = (team.members ?? [])
     .map((m) => {
       const user = m.user as typeof m.user & {
-        profile_image_url?: unknown
-        profileImage?: unknown
-        avatar?: unknown
-      }
+        profile_image_url?: unknown;
+        profileImage?: unknown;
+        avatar?: unknown;
+      };
 
       // 서버에서 내려온 이미지 값 중 문자열만 사용
       const avatarImage =
         getAvatarValue(user.profile_image) ||
         getAvatarValue(user.profile_image_url) ||
         getAvatarValue(user.profileImage) ||
-        getAvatarValue(user.avatar)
+        getAvatarValue(user.avatar);
 
       return {
         id: m.id,
@@ -123,15 +124,15 @@ const convertTeam = (team: TeamFromApi): Team => {
         email: user.email,
         phone: user.phone,
         github: user.github_url || '',
-      }
+      };
     })
-    .sort((a, b) => Number(a.id) - Number(b.id))
+    .sort((a, b) => Number(a.id) - Number(b.id));
 
   // previewImages도 깨진 랜덤 이미지 경로면 기본 아바타로 대체
   const normalizedPreviewImages: string[] = (team.previewImages ?? []).map(
     (image: string, index: number) =>
-      getAvatarValue(image) || getDefaultAvatar(`preview-${team.id}-${index}`)
-  )
+      getAvatarValue(image) || getDefaultAvatar(`preview-${team.id}-${index}`),
+  );
 
   // 로비용 응답이면 previewImages를 화면 표시용 members 형태로만 보정
   const previewMembers =
@@ -146,7 +147,7 @@ const convertTeam = (team: TeamFromApi): Team => {
           email: '',
           phone: '',
           github: '',
-        }))
+        }));
 
   return {
     id: String(team.id),
@@ -157,7 +158,9 @@ const convertTeam = (team: TeamFromApi): Team => {
     previewImages:
       normalizedPreviewImages.length > 0
         ? normalizedPreviewImages
-        : previewMembers.map((m: { avatar?: string }) => m.avatar || '').filter(Boolean),
+        : previewMembers
+            .map((m: { avatar?: string }) => m.avatar || '')
+            .filter(Boolean),
     members: previewMembers,
     tickets: [],
     logs: [],
@@ -165,19 +168,19 @@ const convertTeam = (team: TeamFromApi): Team => {
     links: [],
     userStatuses: Object.fromEntries(
       (team.members ?? []).map((m) => {
-        const statusLabel = m.status || '업무 중'
-        const matched = USER_ACTIVITIES.find((a) => a.label === statusLabel)
+        const statusLabel = m.status || '업무 중';
+        const matched = USER_ACTIVITIES.find((a) => a.label === statusLabel);
         return [
           m.user.uuid,
           {
             label: statusLabel,
             color: matched?.color || 'bg-green-500',
           },
-        ]
+        ];
       }),
     ),
-  }
-}
+  };
+};
 
 /**
  * 특정 팀의 데이터를 최신 상태로 갈아끼워주는 헬퍼 함수
@@ -256,9 +259,22 @@ export const useTeams = (
   // 활성화된 팀의 회의록 목록 조회
   const { data: noteData } = useQuery({
     queryKey: ['noteData', activeTeamId],
-    queryFn: () => getNotesApi(Number(activeTeamId)),
+    queryFn: async () => {
+      try {
+        const response = await getNotesApi(Number(activeTeamId));
+        return response;
+      } catch (error: any) {
+        // 🚀 마지막 회의록 삭제 시 서버가 404를 던지면 빈 배열 구조를 리턴해서 에러를 방어.
+        if (error.response?.status === 404) {
+          return { success: true, data: [] };
+        }
+        throw error;
+      }
+    },
     enabled: !!activeTeamId && !!currentUser,
   });
+
+  const [noteVersion, setNoteVersion] = useState<number | null>(null);
 
   const queryClient = useQueryClient();
 
@@ -447,12 +463,14 @@ export const useTeams = (
           if (isSelected && currentDetail && 'comments' in currentDetail) {
             serverComments = currentDetail.comments.map(
               (c: TaskCommentFromApi): TaskComment => {
-                const writer = baseTeam.members.find((m) => m.name === c.user.name);
+                const writer = baseTeam.members.find(
+                  (m) => m.name === c.user.name,
+                );
                 return {
                   id: c.id,
                   user: c.user.name,
                   // ✅ 2. 찾은 멤버의 avatar(사진)를 userImage 필드에 넣어줍니다.
-                  userImage: writer?.avatar || null, 
+                  userImage: writer?.avatar || null,
                   text: c.content,
                   time: new Date(c.created_at).toLocaleTimeString('ko-KR', {
                     hour12: false,
@@ -520,7 +538,7 @@ export const useTeams = (
     // 아카이브 회의록 데이터 조립
 
     baseTeam.notes =
-      noteData?.data.map((note: TeamArchiveData) => ({
+      (noteData?.data || []).map((note: TeamArchiveData) => ({
         id: note.id,
         type: note.type,
         title: note.title,
@@ -544,9 +562,10 @@ export const useTeams = (
   // 현재 유저가 참여 중인 팀 목록
   const joinedTeams = useMemo(() => {
     if (!currentUser) return [];
-    return teams.filter((team) =>
-      team.isMember === true ||
-      team.members.some((member) => member.name === currentUser.name),
+    return teams.filter(
+      (team) =>
+        team.isMember === true ||
+        team.members.some((member) => member.name === currentUser.name),
     );
   }, [teams, currentUser]);
 
@@ -891,21 +910,111 @@ export const useTeams = (
     });
   };
 
+  // 회의록 상세 버전만 조회
+  const fetchNoteCurrentVersion = async (noteId: number) => {
+    try {
+      const response = await getNoteDetailApi(noteId);
+      if (response.success && response.data) {
+        return response.data.version;
+      }
+      throw new Error('버전 정보를 가져올 수 없습니다.');
+    } catch (error) {
+      if (error.response?.status === 404) {
+        console.warn('이미 삭제된 회의록입니다.');
+        return null;
+      }
+      console.error('버전 조회 실패:', error);
+      return null;
+    }
+  };
+
+  // 회의록 수정 진입 시 버전명 저장 함수
+  const startEditingNote = async (noteId: number) => {
+    try {
+      const response = await getNoteDetailApi(noteId);
+      if (response.success) {
+        setNoteVersion(response.data.version); // 내가 편집을 시작한 '기준' 버전 저장
+        return response.data; // UI에 데이터 뿌려주기용
+      }
+    } catch (error) {
+      console.error('편집 데이터 로드 실패:', error);
+    }
+  };
+
   // 회의록 수정
   const editNote = async (noteId: number, data: NoteRequest) => {
-    await editNoteApi(noteId, data);
+    try {
+      if (noteVersion === null) {
+        alert('버전 정보가 없습니다. 다시 시도해주세요.');
+        return { ok: false };
+      }
 
-    await queryClient.invalidateQueries({
-      queryKey: ['noteData', activeTeamId],
-    });
+      const response = await editNoteApi(noteId, {
+        ...data,
+        version: noteVersion, // 확보한 버전 전송
+      });
+
+      if (response.success) {
+        console.log('✅ [수정 완료] 성공적으로 반영됨');
+        setNoteVersion(null);
+        await queryClient.invalidateQueries({
+          queryKey: ['noteData', activeTeamId],
+        });
+        return { ok: true };
+      }
+    } catch (error: any) {
+      if (error.response?.status === 409) {
+        window.alert(
+          '이미 다른 사용자가 수정했습니다. 최신 내용을 확인해 주세요.',
+        );
+        queryClient.invalidateQueries({ queryKey: ['noteData', activeTeamId] });
+        return { ok: false, conflict: true };
+      }
+      alert('수정 중 오류가 발생했습니다.');
+      return { ok: false };
+    }
   };
 
   // 회의록 삭제
   const deleteNote = async (noteId: number) => {
-    await deleteNoteApi(noteId);
-    await queryClient.invalidateQueries({
-      queryKey: ['noteData', activeTeamId],
-    });
+    if (!window.confirm('정말 이 회의록을 삭제하시겠습니까?')) return;
+
+    try {
+      const currentVersion = await fetchNoteCurrentVersion(noteId);
+
+      if (currentVersion === null) {
+        // 이미 삭제된 경우이므로 사용자에게 알려주고
+        window.alert('이미 삭제된 회의록입니다.');
+        // 목록 갱신해서 유령 데이터를 목록에서 지워줍니다.
+        await queryClient.invalidateQueries({
+          queryKey: ['noteData', activeTeamId],
+        });
+        // 팝업을 닫기 위해 conflict 신호를 보냅니다.
+        return { ok: false, conflict: true };
+      }
+
+      await deleteNoteApi(noteId, currentVersion);
+
+      await queryClient.invalidateQueries({
+        queryKey: ['noteData', activeTeamId],
+      });
+      return { ok: true };
+    } catch (error: unknown) {
+      const status = error.response?.status;
+
+      if (status === 409) {
+        window.alert('이미 수정된 회의록입니다.');
+        queryClient.invalidateQueries({ queryKey: ['noteData', activeTeamId] });
+        return { ok: false, conflict: true }; // 🚀 충돌 리턴
+      } else {
+        if (status === 404) {
+          return { ok: false, conflict: true };
+        }
+        window.alert('삭제에 실패했습니다.');
+      }
+
+      return { ok: false };
+    }
   };
   // 외부 컴포넌트에서 사용할 데이터와 함수 반환
   return {
@@ -944,5 +1053,6 @@ export const useTeams = (
     deleteNote,
     updateProfileImage: uploadImageMutation.mutate,
     isImageUploading: uploadImageMutation.isPending,
+    startEditingNote,
   };
 };

--- a/src/hooks/useTeams.ts
+++ b/src/hooks/useTeams.ts
@@ -6,7 +6,7 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import type {
   Team,
   Ticket,
@@ -263,9 +263,9 @@ export const useTeams = (
       try {
         const response = await getNotesApi(Number(activeTeamId));
         return response;
-      } catch (error: any) {
-        // 🚀 마지막 회의록 삭제 시 서버가 404를 던지면 빈 배열 구조를 리턴해서 에러를 방어.
-        if (error.response?.status === 404) {
+      } catch (error: unknown) {
+        const axiosError = error as AxiosError;
+        if (axiosError.response?.status === 404) {
           return { success: true, data: [] };
         }
         throw error;
@@ -918,8 +918,9 @@ export const useTeams = (
         return response.data.version;
       }
       throw new Error('버전 정보를 가져올 수 없습니다.');
-    } catch (error) {
-      if (error.response?.status === 404) {
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      if (axiosError.response?.status === 404) {
         console.warn('이미 삭제된 회의록입니다.');
         return null;
       }
@@ -949,21 +950,42 @@ export const useTeams = (
         return { ok: false };
       }
 
+      const serverVersion = await fetchNoteCurrentVersion(noteId);
+
+      if (serverVersion === null) {
+        window.alert('이미 삭제된 회의록입니다.');
+        await queryClient.invalidateQueries({
+          queryKey: ['noteData', activeTeamId],
+        });
+        return { ok: false, conflict: true };
+      }
+
+      if (serverVersion !== noteVersion) {
+        window.alert(
+          '이미 다른 사용자가 수정했습니다. 최신 내용을 확인해 주세요.',
+        );
+        await queryClient.invalidateQueries({
+          queryKey: ['noteData', activeTeamId],
+        });
+        return { ok: false, conflict: true };
+      }
+
+      // 버전이 같을 때만 수정 호출
       const response = await editNoteApi(noteId, {
         ...data,
-        version: noteVersion, // 확보한 버전 전송
+        version: noteVersion,
       });
 
       if (response.success) {
-        console.log('✅ [수정 완료] 성공적으로 반영됨');
         setNoteVersion(null);
         await queryClient.invalidateQueries({
           queryKey: ['noteData', activeTeamId],
         });
         return { ok: true };
       }
-    } catch (error: any) {
-      if (error.response?.status === 409) {
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      if (axiosError.response?.status === 409) {
         window.alert(
           '이미 다른 사용자가 수정했습니다. 최신 내용을 확인해 주세요.',
         );
@@ -977,19 +999,14 @@ export const useTeams = (
 
   // 회의록 삭제
   const deleteNote = async (noteId: number) => {
-    if (!window.confirm('정말 이 회의록을 삭제하시겠습니까?')) return;
-
     try {
       const currentVersion = await fetchNoteCurrentVersion(noteId);
 
       if (currentVersion === null) {
-        // 이미 삭제된 경우이므로 사용자에게 알려주고
         window.alert('이미 삭제된 회의록입니다.');
-        // 목록 갱신해서 유령 데이터를 목록에서 지워줍니다.
         await queryClient.invalidateQueries({
           queryKey: ['noteData', activeTeamId],
         });
-        // 팝업을 닫기 위해 conflict 신호를 보냅니다.
         return { ok: false, conflict: true };
       }
 
@@ -998,19 +1015,28 @@ export const useTeams = (
       await queryClient.invalidateQueries({
         queryKey: ['noteData', activeTeamId],
       });
+      setNoteVersion(null);
       return { ok: true };
     } catch (error: unknown) {
-      const status = error.response?.status;
+      const axiosError = error as AxiosError;
+      const status = axiosError.response?.status;
+
+      if (status === 404) {
+        window.alert('이미 삭제된 회의록입니다.');
+        await queryClient.invalidateQueries({
+          queryKey: ['noteData', activeTeamId],
+        });
+        return { ok: false, conflict: true };
+      }
 
       if (status === 409) {
-        window.alert('이미 수정된 회의록입니다.');
-        queryClient.invalidateQueries({ queryKey: ['noteData', activeTeamId] });
-        return { ok: false, conflict: true }; // 🚀 충돌 리턴
-      } else {
-        if (status === 404) {
-          return { ok: false, conflict: true };
-        }
-        window.alert('삭제에 실패했습니다.');
+        window.alert(
+          '다른 사용자가 회의록을 수정했습니다.최신 내용을 확인해 주세요',
+        );
+        await queryClient.invalidateQueries({
+          queryKey: ['noteData', activeTeamId],
+        });
+        return { ok: false, conflict: true };
       }
 
       return { ok: false };

--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -145,7 +145,9 @@ export const Archive = ({
             {activeTeam.notes.map((note) => (
               <div
                 key={note.id}
-                onClick={() => setSelectedNote(note)}
+                onClick={() => {
+                  setSelectedNote(note);
+                }}
                 className="p-6 rounded-3xl border border-slate-100 bg-slate-50/30 hover:bg-white hover:border-blue-200 hover:shadow-xl transition-all cursor-pointer group flex flex-col h-50"
               >
                 <div className="flex justify-between items-start mb-3">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -187,7 +187,12 @@ export interface PusherCommentData {
 type ArchiveType = 'NOTE' | 'LINK' | 'PDF';
 
 // 알림 타입 정의
-export type NotificationType = "NEW_TASK" | "TASK_UPDATED" | "TASK_DELETED" | "STATUS_CHANGED" | "NEW_COMMENT";
+export type NotificationType =
+  | 'NEW_TASK'
+  | 'TASK_UPDATED'
+  | 'TASK_DELETED'
+  | 'STATUS_CHANGED'
+  | 'NEW_COMMENT';
 
 // 알림 api 응답 타입 정의
 export interface NotificationItem {
@@ -218,6 +223,7 @@ export interface TeamArchiveData {
   title: string;
   content: string;
   created_at: string;
+  version?: number; // 회의록 버전 관리용 (낙관적 락)
 }
 
 /**


### PR DESCRIPTION
## 작업 내용
- 회의록 상세 조회 api를 통해 회의록 version값 조회 및 상태 관리
- 수정, 삭제 시 요청 version 파라미터값 추가
- 수정, 삭제 시 409 응답 처리

## 추후 처리 내용
- 회의록 삭제 충돌 발생 시 로직 이슈로 콘솔에 회의록상세조회 404 에러가 찍히나 화면상으로는 이슈가 없어 일단 에러수정은 시간상 추후 진행할 예정